### PR TITLE
Added support for isKindOfClass: to object mocks

### DIFF
--- a/Source/OCMockito/MKTObjectMock.m
+++ b/Source/OCMockito/MKTObjectMock.m
@@ -36,6 +36,11 @@
 
 #pragma mark NSObject protocol
 
+- (BOOL)isKindOfClass:(Class)aClass
+{
+    return [mockedClass isSubclassOfClass:aClass];
+}
+
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
     return [mockedClass instancesRespondToSelector:aSelector];

--- a/Source/Tests/MKTObjectMockTest.m
+++ b/Source/Tests/MKTObjectMockTest.m
@@ -49,6 +49,33 @@
     assertThat(signature, is(nilValue()));
 }
 
+- (void)testMockShouldBeKindOfSameClass
+{
+    // given
+    NSString *mockString = mock([NSString class]);
+    
+    //then
+    STAssertTrue([mockString isKindOfClass:[NSString class]], nil);
+}
+
+- (void)testMockShouldBeKindOfSubclass
+{
+    // given
+    NSString *mockString = mock([NSMutableString class]);
+    
+    //then
+    STAssertTrue([mockString isKindOfClass:[NSString class]], nil);
+}
+
+- (void)testMockShouldNotBeKindOfDifferentClass
+{
+    // given
+    NSString *mockString = mock([NSString class]);
+    
+    //then
+    STAssertFalse([mockString isKindOfClass:[NSArray class]], nil);
+}
+
 - (void)testMockShouldRespondToKnownSelector
 {
     // given


### PR DESCRIPTION
It would be nice to have mocks respond properly to isKindOfClass:

``` obj-c
id someObject = mock([NSString class]);
/// ...
if ([someObject isKindOfClass:[NSString class]]) {
/// ...
```

I used the existing implementation of respondsToSelector: as a guide for both the implementation and the tests.
