### PR TITLE
Added willReturnStruct:

### DIFF
--- a/Source/OCMockito/MKTBaseMockObject.m
+++ b/Source/OCMockito/MKTBaseMockObject.m
@@ -110,6 +110,14 @@
     HANDLE_METHOD_RETURN_TYPE(unsigned long long, unsignedLongLong)
     HANDLE_METHOD_RETURN_TYPE(float, float)
     HANDLE_METHOD_RETURN_TYPE(double, double)
+  else if ((strchr(methodReturnType,'{') - methodReturnType) == 0)
+    {
+    void *answer = malloc([methodSignature methodReturnLength]);
+    [[_invocationContainer findAnswerFor:invocation] getValue:answer];
+    [invocation setReturnValue:answer];
+    free(answer);
+    }
+
 }
 
 

--- a/Source/OCMockito/MKTOngoingStubbing.h
+++ b/Source/OCMockito/MKTOngoingStubbing.h
@@ -67,4 +67,7 @@
 /// Stubs given @c double as return value.
 - (MKTOngoingStubbing *)willReturnDouble:(double)value;
 
+/// Stubs given <code>struct</code> as return value.
+- (MKTOngoingStubbing *)willReturnStruct:(void *)value;
+
 @end

--- a/Source/OCMockito/MKTOngoingStubbing.m
+++ b/Source/OCMockito/MKTOngoingStubbing.m
@@ -53,6 +53,12 @@ DEFINE_RETURN_METHOD(NSUInteger, UnsignedInteger)
 DEFINE_RETURN_METHOD(float, Float)
 DEFINE_RETURN_METHOD(double, Double)
 
+- (MKTOngoingStubbing *)willReturnStruct:(void *)value
+{
+  NSValue *answer = [NSValue valueWithBytes:value objCType:@encode(typeof(value))];
+  [_invocationContainer addAnswer:answer];
+  return self;
+}
 
 #pragma mark MKTPrimitiveArgumentMatching
 

--- a/Source/Tests/StubObjectTest.m
+++ b/Source/Tests/StubObjectTest.m
@@ -21,6 +21,11 @@
 
 
 @interface ReturningObject : NSObject
+
+typedef struct {
+  int aMember;
+} aStruct;
+
 @end
 
 @implementation ReturningObject
@@ -46,6 +51,7 @@
 - (NSUInteger)methodReturningUnsignedInteger { return 0; }
 - (float)methodReturningFloat { return 0; }
 - (double)methodReturningDouble { return 0; }
+- (aStruct)methodReturningStruct { aStruct returnedStruct = {0}; return returnedStruct; }
 
 @end
 
@@ -287,6 +293,19 @@
     
     // then
     assertThatDouble([mockObject methodReturningDouble], equalToDouble(42));
+}
+
+- (void)testStubbedMethodShouldReturnGivenStruct
+{
+  int anInt = 123;
+  aStruct someStruct = { anInt };
+
+  // when
+  [given([mockObject methodReturningStruct]) willReturnStruct:&someStruct];
+  someStruct = [mockObject methodReturningStruct];
+
+  // then
+  assertThat(@(someStruct.aMember), is(@(anInt)));
 }
 
 @end

--- a/Source/Tests/StubProtocolTest.m
+++ b/Source/Tests/StubProtocolTest.m
@@ -19,6 +19,9 @@
     #import <OCHamcrestIOS/OCHamcrestIOS.h>
 #endif
 
+typedef struct {
+  int aMember;
+} aStruct;
 
 @protocol ReturningProtocol <NSObject>
 
@@ -26,6 +29,7 @@
 - (id)methodReturningObjectWithArg:(id)arg;
 - (id)methodReturningObjectWithIntArg:(int)arg;
 - (short)methodReturningShort;
+- (aStruct)methodReturningStruct;
 
 @end
 
@@ -118,4 +122,16 @@
     assertThatShort([mockProtocol methodReturningShort], equalToShort(42));
 }
 
+- (void)testStubbedMethodShouldReturnGivenStruct
+{
+  int anInt = 123;
+  aStruct someStruct = { anInt };
+
+  // when
+  [given([mockProtocol methodReturningStruct]) willReturnStruct:&someStruct];
+  someStruct = [mockProtocol methodReturningStruct];
+
+  // then
+  assertThat(@(someStruct.aMember), is(@(anInt)));
+}
 @end


### PR DESCRIPTION
Possible solution to https://github.com/jonreid/OCMockito/issues/16.
I chose to hide the NSValue boxing by accepting `void *` but we could accept `NSValue` and have the user box the value.
