### PR TITLE
Add willAnswer stubbing method.

### DIFF
--- a/Source/OCMockito/MKTBaseMockObject.m
+++ b/Source/OCMockito/MKTBaseMockObject.m
@@ -17,7 +17,6 @@
 #import "MKTMockSettings.h"
 #import "MKTVerificationData.h"
 #import "MKTVerificationMode.h"
-#import "MKTMockSettings.h"
 
 
 @implementation MKTBaseMockObject
@@ -107,11 +106,11 @@
         [_settings useDefaultAnswerForInvocation:invocation];
 }
 
-#define HANDLE_METHOD_RETURN_TYPE(type, typeName)               \
-    else if (strcmp(methodReturnType, @encode(type)) == 0)      \
-    {                                                           \
-        type answer = [[stub answer] typeName ## Value];        \
-        [invocation setReturnValue:&answer];                    \
+#define HANDLE_METHOD_RETURN_TYPE(type, typeName)                    \
+    else if (strcmp(methodReturnType, @encode(type)) == 0)           \
+    {                                                                \
+        type answer = [[stub answer](invocation) typeName ## Value]; \
+        [invocation setReturnValue:&answer];                         \
     }
 
 - (void)useExistingAnswerInStub:(MKTStubbedInvocationMatcher *)stub forInvocation:(NSInvocation *)invocation
@@ -120,7 +119,7 @@
     const char* methodReturnType = [methodSignature methodReturnType];
     if (MKTTypeEncodingIsObjectOrClass(methodReturnType))
     {
-        __unsafe_unretained id answer = [stub answer];
+        __unsafe_unretained id answer = [stub answer](invocation);
         [invocation setReturnValue:&answer];
     }
     HANDLE_METHOD_RETURN_TYPE(char, char)

--- a/Source/OCMockito/MKTInvocationContainer.m
+++ b/Source/OCMockito/MKTInvocationContainer.m
@@ -8,7 +8,6 @@
 
 #import "MKTInvocationContainer.h"
 
-#import "MKTMockingProgress.h"
 #import "MKTStubbedInvocationMatcher.h"
 
 
@@ -47,7 +46,7 @@
     [_invocationForStubbing setMatcher:matcher atIndex:argumentIndex];
 }
 
-- (void)addAnswer:(id)answer
+- (void)addAnswer:(id (^)(NSInvocation *))answer
 {
     [_registeredInvocations removeLastObject];
 

--- a/Source/OCMockito/MKTOngoingStubbing.h
+++ b/Source/OCMockito/MKTOngoingStubbing.h
@@ -67,4 +67,7 @@
 /// Stubs given @c double as return value.
 - (MKTOngoingStubbing *)willReturnDouble:(double)value;
 
+/// Stubs given a block used to determine the return value.
+- (MKTOngoingStubbing *)willAnswer:(id (^)(NSInvocation *))invocation;
+
 @end

--- a/Source/OCMockito/MKTOngoingStubbing.m
+++ b/Source/OCMockito/MKTOngoingStubbing.m
@@ -26,15 +26,16 @@
 
 - (MKTOngoingStubbing *)willReturn:(id)object
 {
-    [_invocationContainer addAnswer:object];
-    return self;
+    return [self willAnswer:^(NSInvocation *invocation)
+    {
+        return object;
+    }];
 }
 
 #define DEFINE_RETURN_METHOD(type, typeName)                        \
     - (MKTOngoingStubbing *)willReturn ## typeName:(type)value      \
     {                                                               \
-        [_invocationContainer addAnswer:@(value)];                  \
-        return self;                                                \
+        return [self willReturn:@(value)];                          \
     }
 
 DEFINE_RETURN_METHOD(BOOL, Bool)
@@ -53,6 +54,11 @@ DEFINE_RETURN_METHOD(NSUInteger, UnsignedInteger)
 DEFINE_RETURN_METHOD(float, Float)
 DEFINE_RETURN_METHOD(double, Double)
 
+- (MKTOngoingStubbing *)willAnswer:(id (^)(NSInvocation *))answer
+{
+    [_invocationContainer addAnswer:answer];
+    return self;
+}
 
 #pragma mark MKTPrimitiveArgumentMatching
 

--- a/Source/OCMockito/MKTStubbedInvocationMatcher.h
+++ b/Source/OCMockito/MKTStubbedInvocationMatcher.h
@@ -11,7 +11,7 @@
 
 @interface MKTStubbedInvocationMatcher : MKTInvocationMatcher
 
-@property (nonatomic, strong) id answer;
+@property (nonatomic, copy) id (^answer)(NSInvocation *invocation);
 
 - (id)initCopyingInvocationMatcher:(MKTInvocationMatcher *)other;
 

--- a/Source/OCMockito/MKTStubber.m
+++ b/Source/OCMockito/MKTStubber.m
@@ -37,7 +37,15 @@
 
 - (void)doReturn:(id)obj
 {
-    [_answers addObject:obj];
+    [self doAnswer:^id(NSInvocation *invocation)
+    {
+        return obj;
+    }];
+}
+
+- (void)doAnswer:(id (^)(NSInvocation *))answer
+{
+    [_answers addObject:answer];
 }
 
 @end

--- a/Source/Tests/StubObjectTest.m
+++ b/Source/Tests/StubObjectTest.m
@@ -289,4 +289,31 @@
     assertThatDouble([mockObject methodReturningDouble], equalToDouble(42));
 }
 
+- (void)testStubbedMethodShouldAnswerUsingGivenBlock
+{
+    // when
+    [given([mockObject methodReturningObject]) willAnswer:^(NSInvocation *invocation)
+    {
+        return @"FOO";
+    }];
+
+    // then
+    assertThat([mockObject methodReturningObject], is(@"FOO"));
+}
+
+- (void)testStubbedMethodShouldNotStoreAnswerValue
+{
+    // when
+    NSMutableString *string = [@"FOO" mutableCopy];
+    [given([mockObject methodReturningObject]) willAnswer:^(NSInvocation *invocation)
+    {
+        return string;
+    }];
+    [mockObject methodReturningObject];
+    [string appendString:@"BAR"];
+
+    // then
+    assertThat([mockObject methodReturningObject], is(@"FOOBAR"));
+}
+
 @end


### PR DESCRIPTION
This allows more flexible stubbing using a block, similar to the doAnswer method in Mockito. What do you think?

I'm a bit unsure about exposing the NSInvocation directly. Maybe it should be encapsulated in an immutable wrapper similar to [InvocationOnMock](http://mockito.googlecode.com/svn/branches/1.7/javadoc/org/mockito/invocation/InvocationOnMock.html).