### PR TITLE
Use path specified in DOXYGEN environment variable, if set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ $ cd Source
 $ ./MakeDistribution.sh
 ```
 
+If you have doxygen installed somewhere other than the Applications folder use this instead:
+
+```sh
+$ git submodule update --init
+$ cd Source
+$ DOXYGEN=/usr/local/bin/doxygen ./MakeDistribution.sh
+```
+
 Or just use the pre-built release available at
 [QualityCoding.org](http://qualitycoding.org/resources/).
 

--- a/Source/MakeDocumentation.sh
+++ b/Source/MakeDocumentation.sh
@@ -1,7 +1,7 @@
-DOXYGEN=/Applications/Doxygen.app/Contents/Resources/doxygen
+DOXYGEN=${DOXYGEN-/Applications/Doxygen.app/Contents/Resources/doxygen}
 
 if ! [ -f $DOXYGEN ]; then
-  echo :: error : Requires Doxygen in Applications folder
+  echo :: error : Requires Doxygen in the `dirname $DOXYGEN` folder
   exit 1
 fi
 


### PR DESCRIPTION
The MakeDocumentation.sh script expected doxygen to be installed in the Applications folder, but on some systems doxygen will be installed elsewhere. This modification makes it possible to generate the documentation using a different path for doxygen by setting the DOXYGEN environment variable before invoking the MakeDocumentation.sh script.
