### PR TITLE
Crash when passing stack block arguments to methods of mock objects

### DIFF
--- a/Source/OCMockito/MKTInvocationMatcher.m
+++ b/Source/OCMockito/MKTInvocationMatcher.m
@@ -24,6 +24,10 @@
 @interface MKTInvocationMatcher ()
 @end
 
+@interface NSObject ()
+- (BOOL)isBlock;
+@end
+
 
 @implementation MKTInvocationMatcher
 
@@ -82,7 +86,7 @@
             
             id <HCMatcher> matcher;
             if (argument != nil)
-                matcher = HCWrapInMatcher(argument);
+                matcher = HCWrapInMatcher([argument isBlock] ? [argument copy] : argument);
             else
                 matcher = nilValue();
             


### PR DESCRIPTION
When normal (non-matcher) objects are passed as arguments to a mock, they are wrapped in a matcher and retained by the mock.

This causes some trouble with stack blocks, as the matcher may outlast the block's stack frame. When it is deallocated, it releases the block. Hilarity ensues.

NSObject has a private isBlock method, which could be used to decide whether or not to copy the argument when wrapping it up. This fixes it for me, although I can't think of a good way to add a test case.
