### PR TITLE
Async versions of each of the verify modes.

### DIFF
--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -124,6 +124,8 @@
 		638F68DA150FC21A0081DEE6 /* MKTClassObjectMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */; };
 		638F68DD150FC3210081DEE6 /* MKTClassObjectMockTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68DC150FC3210081DEE6 /* MKTClassObjectMockTest.m */; };
 		638F68DE150FC3210081DEE6 /* MKTClassObjectMockTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68DC150FC3210081DEE6 /* MKTClassObjectMockTest.m */; };
+		6525714317D14C2300577580 /* MKTExactTimesTest.m in Resources */ = {isa = PBXBuildFile; fileRef = 6525714217D14C2300577580 /* MKTExactTimesTest.m */; };
+		6525714417D1510100577580 /* MKTExactTimesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6525714217D14C2300577580 /* MKTExactTimesTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -223,6 +225,7 @@
 		638F68D5150FC21A0081DEE6 /* MKTClassObjectMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTClassObjectMock.h; sourceTree = "<group>"; };
 		638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTClassObjectMock.m; sourceTree = "<group>"; };
 		638F68DC150FC3210081DEE6 /* MKTClassObjectMockTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTClassObjectMockTest.m; sourceTree = "<group>"; };
+		6525714217D14C2300577580 /* MKTExactTimesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTExactTimesTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -351,22 +354,23 @@
 		08BDD5C31350C59C00E5A443 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				085CE8F1172A0D43004D070D /* BlockMatchingTest.m */,
 				361533CB153F283800BB982B /* MKTAtLeastTimesTest.m */,
+				6525714217D14C2300577580 /* MKTExactTimesTest.m */,
 				638F68DC150FC3210081DEE6 /* MKTClassObjectMockTest.m */,
-				089A8C2213552DE7003E7D27 /* MKTObjectMockTest.m */,
-				08E9DC271516739A00BD7FB4 /* MKTObjectAndProtocolMockTest.m */,
-				085A8BC6150718E30018EC66 /* MKTProtocolMockTest.m */,
 				08F189FC135A6D1300F76379 /* MKTInvocationMatcherTest.m */,
 				08F189E21359661E00F76379 /* MKTMockingProgressTest.m */,
-				085CE8F1172A0D43004D070D /* BlockMatchingTest.m */,
+				08E9DC271516739A00BD7FB4 /* MKTObjectAndProtocolMockTest.m */,
+				089A8C2213552DE7003E7D27 /* MKTObjectMockTest.m */,
+				085A8BC6150718E30018EC66 /* MKTProtocolMockTest.m */,
 				08FD4B1E1509A6C40004E1FA /* MockTestCase.h */,
 				08FD4B1F1509A6C40004E1FA /* MockTestCase.m */,
 				089A8C3113555D0C003E7D27 /* StubObjectTest.m */,
 				08FD4B251509B8740004E1FA /* StubProtocolTest.m */,
 				08E9DC1B15163D4600BD7FB4 /* VerifyClassObjectTest.m */,
-				08FD4B221509A93B0004E1FA /* VerifyProtocolTest.m */,
-				085D2FB11351080400EBBE91 /* VerifyObjectTest.m */,
 				08E9DC2D1516777100BD7FB4 /* VerifyObjectAndProtocolTest.m */,
+				085D2FB11351080400EBBE91 /* VerifyObjectTest.m */,
+				08FD4B221509A93B0004E1FA /* VerifyProtocolTest.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -551,6 +555,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6525714317D14C2300577580 /* MKTExactTimesTest.m in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -708,6 +713,7 @@
 				08E9DC2E1516777200BD7FB4 /* VerifyObjectAndProtocolTest.m in Sources */,
 				361533CC153F283800BB982B /* MKTAtLeastTimesTest.m in Sources */,
 				085CE8F5172A1BCA004D070D /* BlockMatchingTest.m in Sources */,
+				6525714417D1510100577580 /* MKTExactTimesTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/OCMockito/MKTAtLeastTimes.h
+++ b/Source/OCMockito/MKTAtLeastTimes.h
@@ -12,7 +12,7 @@
 
 @interface MKTAtLeastTimes : NSObject <MKTVerificationMode>
 
-+ (id)timesWithMinimumCount:(NSUInteger)minimumExpectedNumberOfInvocations;
-- (id)initWithMinimumCount:(NSUInteger)minimumExpectedNumberOfInvocations;
++ (id)timesWithMinimumCount:(NSUInteger)minimumExpectedNumberOfInvocations eventually:(BOOL)eventually;
+- (id)initWithMinimumCount:(NSUInteger)minimumExpectedNumberOfInvocations eventually:(BOOL)eventually;
 
 @end

--- a/Source/OCMockito/MKTExactTimes.h
+++ b/Source/OCMockito/MKTExactTimes.h
@@ -12,7 +12,7 @@
 
 @interface MKTExactTimes : NSObject <MKTVerificationMode>
 
-+ (id)timesWithCount:(NSUInteger)expectedNumberOfInvocations;
-- (id)initWithCount:(NSUInteger)expectedNumberOfInvocations;
++ (id)timesWithCount:(NSUInteger)expectedNumberOfInvocations eventually:(BOOL)eventually;
+- (id)initWithCount:(NSUInteger)expectedNumberOfInvocations eventually:(BOOL)eventually;
 
 @end

--- a/Source/OCMockito/MKTVerificationMode.h
+++ b/Source/OCMockito/MKTVerificationMode.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class MKTVerificationData;
+@class MKTVerificationModeResult;
 
 
 @protocol MKTVerificationMode <NSObject>

--- a/Source/OCMockito/OCMockito.h
+++ b/Source/OCMockito/OCMockito.h
@@ -144,6 +144,7 @@ OBJC_EXPORT id MKTVerifyCountWithLocation(id mock, id mode, id testCase, const c
 
 
 OBJC_EXPORT id MKTTimes(NSUInteger wantedNumberOfInvocations);
+OBJC_EXPORT id MKTEventuallyTimes(NSUInteger wantedNumberOfInvocations);
 
 /**
     Verifies exact number of invocations.
@@ -160,8 +161,24 @@ OBJC_EXPORT id MKTTimes(NSUInteger wantedNumberOfInvocations);
     #define times(wantedNumberOfInvocations) MKTTimes(wantedNumberOfInvocations)
 #endif
 
+/**
+    Verifies exact number of invocations now, or at some time in the near future.
+
+    Example:
+@code
+[verifyCount(mockObject, eventuallyTimes(2)) someMethod:@"some arg"];
+@endcode
+
+    (In the event of a name clash, don't \#define @c MOCKITO_SHORTHAND and use the synonym
+    @c MKTEventuallyTimes instead.)
+ */
+#ifdef MOCKITO_SHORTHAND
+    #define eventuallyTimes(wantedNumberOfInvocations) MKTEventuallyTimes(wantedNumberOfInvocations)
+#endif
+
 
 OBJC_EXPORT id MKTNever(void);
+OBJC_EXPORT id MKTEventuallyNever(void);
 
 /**
     Verifies that interaction did not happen.
@@ -178,8 +195,24 @@ OBJC_EXPORT id MKTNever(void);
     #define never() MKTNever()
 #endif
 
+/**
+    Verifies that interaction did not happen now, or at some time in the near future.
+
+    Example:
+    @code
+    [verifyCount(mockObject, eventuallyNever()) someMethod:@"some arg"];
+    @endcode
+
+    (In the event of a name clash, don't \#define @c MOCKITO_SHORTHAND and use the synonym
+    @c MKTEventuallyNever instead.)
+ */
+#ifdef MOCKITO_SHORTHAND
+    #define eventuallyNever() MKTEventuallyNever()
+#endif
+
 
 OBJC_EXPORT id MKTAtLeast(NSUInteger minimumWantedNumberOfInvocations);
+OBJC_EXPORT id MKTEventuallyAtLeast(NSUInteger minimumWantedNumberOfInvocations);
 
 /**
     Verifies minimum number of invocations.
@@ -199,8 +232,27 @@ OBJC_EXPORT id MKTAtLeast(NSUInteger minimumWantedNumberOfInvocations);
     #define atLeast(minimumWantedNumberOfInvocations) MKTAtLeast(minimumWantedNumberOfInvocations)
 #endif
 
+/**
+    Verifies minimum number of invocations now, or at some time in the near future.
+
+    The verification will succeed if the specified invocation happened the number of times
+    specified or more.
+
+    Example:
+@code
+[verifyCount(mockObject, eventuallyAtLeast(2)) someMethod:@"some arg"];
+@endcode
+
+    (In the event of a name clash, don't \#define @c MOCKITO_SHORTHAND and use the synonym
+    @c MKTEventuallyAtLeast instead.)
+ */
+#ifdef MOCKITO_SHORTHAND
+    #define eventuallyAtLeast(minimumWantedNumberOfInvocations) MKTEventuallyAtLeast(minimumWantedNumberOfInvocations)
+#endif
+
 
 OBJC_EXPORT id MKTAtLeastOnce(void);
+OBJC_EXPORT id MKTEventuallyAtLeastOnce(void);
 
 /**
     Verifies that interaction happened once or more.
@@ -216,3 +268,33 @@ OBJC_EXPORT id MKTAtLeastOnce(void);
 #ifdef MOCKITO_SHORTHAND
     #define atLeastOnce() MKTAtLeastOnce()
 #endif
+
+/**
+    Verifies that interaction happened once or more now, or at some time in the near future.
+
+    Example:
+@code
+[verifyCount(mockObject, atLeastOnce()) someMethod:@"some arg"];
+@endcode
+
+    (In the event of a name clash, don't \#define @c MOCKITO_SHORTHAND and use the synonym
+    @c MKTEventuallyAtLeastOnce instead.)
+ */
+#ifdef MOCKITO_SHORTHAND
+    #define eventuallyAtLeastOnce() MKTEventuallyAtLeastOnce()
+#endif
+
+
+/**
+ Retrieves the default timeout used by @c eventuallyTimes, @c eventuallyNever,
+ @c eventuallyAtLeast and @c eventuallyAtLeastOnce.
+
+ The default value is 1 second.
+ */
+OBJC_EXPORT NSTimeInterval MKT_eventuallyDefaultTimeout(void);
+
+/**
+ Sets the default timeout used by @c eventuallyTimes, @c eventuallyNever,
+ @c eventuallyAtLeast and @c eventuallyAtLeastOnce.
+ */
+OBJC_EXPORT void MKT_setEventuallyDefaultTimeout(NSTimeInterval defaultTimeout);

--- a/Source/OCMockito/OCMockito.m
+++ b/Source/OCMockito/OCMockito.m
@@ -66,7 +66,12 @@ id MKTVerifyCountWithLocation(id mock, id mode, id testCase, const char *fileNam
 
 id MKTTimes(NSUInteger wantedNumberOfInvocations)
 {
-    return [MKTExactTimes timesWithCount:wantedNumberOfInvocations];
+    return [MKTExactTimes timesWithCount:wantedNumberOfInvocations eventually:NO];
+}
+
+id MKTEventuallyTimes(NSUInteger wantedNumberOfInvocations)
+{
+    return [MKTExactTimes timesWithCount:wantedNumberOfInvocations eventually:YES];
 }
 
 id MKTNever()
@@ -74,12 +79,41 @@ id MKTNever()
     return MKTTimes(0);
 }
 
+id MKTEventuallyNever()
+{
+    return MKTEventuallyTimes(0);
+}
+
 id MKTAtLeast(NSUInteger minimumWantedNumberOfInvocations)
 {
-    return [MKTAtLeastTimes timesWithMinimumCount:minimumWantedNumberOfInvocations];
+    return [MKTAtLeastTimes timesWithMinimumCount:minimumWantedNumberOfInvocations eventually:NO];
+}
+
+id MKTEventuallyAtLeast(NSUInteger minimumWantedNumberOfInvocations)
+{
+    return [MKTAtLeastTimes timesWithMinimumCount:minimumWantedNumberOfInvocations eventually:YES];
 }
 
 id MKTAtLeastOnce()
 {
     return MKTAtLeast(1);
+}
+
+id MKTEventuallyAtLeastOnce()
+{
+    return MKTEventuallyAtLeast(1);
+}
+
+
+
+static NSTimeInterval sEventuallyDefaultTimeout = 1.0; // seconds
+
+NSTimeInterval MKT_eventuallyDefaultTimeout()
+{
+    return sEventuallyDefaultTimeout;
+}
+
+void MKT_setEventuallyDefaultTimeout(NSTimeInterval defaultTimeout)
+{
+    sEventuallyDefaultTimeout = defaultTimeout;
 }

--- a/Source/Tests/MKTExactTimesTest.m
+++ b/Source/Tests/MKTExactTimesTest.m
@@ -1,12 +1,12 @@
 //
-//  OCMockito - MKTAtLeastTimesTest.m
+//  OCMockito - MKTExactTimesTest.m
 //  Copyright 2013 Jonathan M. Reid. See LICENSE.txt
 //  
-//  Created by Markus Gasser on 18.04.12.
+//  Created by Daniel Rodríguez Troitiño on 30.08.13.
 //  Source: https://github.com/jonreid/OCMockito
 //
 
-#import "MKTAtLeastTimes.h"
+#import "MKTExactTimes.h"
 
 #define MOCKITO_SHORTHAND
 #import "OCMockito.h"
@@ -25,10 +25,10 @@
 #endif
 
 
-@interface MKTAtLeastTimesTest : SenTestCase
+@interface MKTExactTimesTest : SenTestCase
 @end
 
-@implementation MKTAtLeastTimesTest
+@implementation MKTExactTimesTest
 {
     BOOL shouldPassAllExceptionsUp;
     MKTVerificationData *emptyData;
@@ -59,107 +59,107 @@
 - (void)testVerificationShouldFailForEmptyDataIfCountIsNonzero
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:NO];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:NO];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
     
     // then
-    STAssertThrows([atLeastTimes verifyData:emptyData], @"verify should throw an exception for empty data");
+    STAssertThrows([exactTimes verifyData:emptyData], @"verify should throw an exception for empty data");
 }
 
 - (void)testVerificationShouldEventuallyFailForEmptyDataIfCountIsNonzero
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:YES];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:YES];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
 
     // then
-    STAssertThrows([atLeastTimes verifyData:emptyData], @"verify should eventually throw an exception for empty data");
+    STAssertThrows([exactTimes verifyData:emptyData], @"verify should eventually throw an exception for empty data");
 }
 
 - (void)testVerificationShouldFailForTooLittleInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:2 eventually:NO];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:2 eventually:NO];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
     [[emptyData invocations] setInvocationForPotentialStubbing:invocation]; // 1 call, but expect 2
     
     // then
-    STAssertThrows([atLeastTimes verifyData:emptyData], @"verify should throw an exception for too little invocations");
+    STAssertThrows([exactTimes verifyData:emptyData], @"verify should throw an exception for too little invocations");
 }
 
 - (void)testVerificationShouldEventuallyFailForTooLittleInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:2 eventually:YES];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:2 eventually:YES];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
     [[emptyData invocations] setInvocationForPotentialStubbing:invocation]; // 1 call, but expect 2
 
     // then
-    STAssertThrows([atLeastTimes verifyData:emptyData], @"verify should eventually throw an exception for too little invocations");
+    STAssertThrows([exactTimes verifyData:emptyData], @"verify should eventually throw an exception for too little invocations");
 }
 
 - (void)testVerificationShouldSucceedForMinimumCountZero
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:0 eventually:NO];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:0 eventually:NO];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
     
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should succeed for atLeast(0)");
+    STAssertNoThrow([exactTimes verifyData:emptyData], @"verify should succeed for times(0)");
 }
 
 - (void)testVerificationShouldEventuallySucceedForMinimumCountZero
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:0 eventually:YES];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:0 eventually:YES];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
 
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should eventually succeed for atLeast(0)");
+    STAssertNoThrow([exactTimes verifyData:emptyData], @"verify should eventually succeed for eventuallyTimes(0)");
 }
 
 - (void)testVerificationShouldSucceedForExactNumberOfInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:NO];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:NO];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
     [[emptyData invocations] setInvocationForPotentialStubbing:invocation];
     
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should succeed for exact number of invocations matched");
+    STAssertNoThrow([exactTimes verifyData:emptyData], @"verify should succeed for exact number of invocations matched");
 }
 
 - (void)testVerificationShouldEventuallySucceedForExactNumberOfInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:YES];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:YES];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
     [[emptyData invocations] setInvocationForPotentialStubbing:invocation];
 
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should eventually succeed for exact number of invocations matched");
+    STAssertNoThrow([exactTimes verifyData:emptyData], @"verify should eventually succeed for exact number of invocations matched");
 }
 
 - (void)testVerificationShouldAsynchronouslySucceedForExactNumberOfInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:YES];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:YES];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
@@ -169,13 +169,13 @@
     });
 
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should eventually succeed for exact number of invocations matched");
+    STAssertNoThrow([exactTimes verifyData:emptyData], @"verify should eventually succeed for exact number of invocations matched");
 }
 
-- (void)testVerificationShouldSucceedForMoreInvocations
+- (void)testVerificationShouldFailForMoreInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:NO];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:NO];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
@@ -183,13 +183,13 @@
     [[emptyData invocations] setInvocationForPotentialStubbing:invocation]; // 2 calls to the expected method
     
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should succeed for more invocations matched");
+    STAssertThrows([exactTimes verifyData:emptyData], @"verify should throw an exception for more invocations matched");
 }
 
-- (void)testVerificationShouldEventuallySucceedForMoreInvocations
+- (void)testVerificationShouldEventuallyFailForMoreInvocations
 {
     // given
-    MKTAtLeastTimes *atLeastTimes = [MKTAtLeastTimes timesWithMinimumCount:1 eventually:YES];
+    MKTExactTimes *exactTimes = [MKTExactTimes timesWithCount:1 eventually:YES];
 
     // when
     [[emptyData wanted] setExpectedInvocation:invocation];
@@ -197,25 +197,25 @@
     [[emptyData invocations] setInvocationForPotentialStubbing:invocation]; // 2 calls to the expected method
 
     // then
-    STAssertNoThrow([atLeastTimes verifyData:emptyData], @"verify should eventually succeed for more invocations matched");
+    STAssertThrows([exactTimes verifyData:emptyData], @"verify should eventually throw an exception for more invocations matched");
 }
 
 
 #pragma mark - Test From Top-Level
 
-- (void)testAtLeastInActionForExactCount
+- (void)testTimesInActionForExactCount
 {
     // given
     NSMutableArray *mockArray = mock([NSMutableArray class]);
-    
+
     // when
     [mockArray removeAllObjects];
-    
+
     // then
-    [verifyCount(mockArray, atLeast(1)) removeAllObjects];
+    [verifyCount(mockArray, times(1)) removeAllObjects];
 }
 
-- (void)testEventuallyAtLeastInActionForExactCount
+- (void)testEventuallyTimesInActionForExactCount
 {
     // given
     NSMutableArray *mockArray = mock([NSMutableArray class]);
@@ -227,110 +227,109 @@
     });
 
     // then
-    [verifyCount(mockArray, eventuallyAtLeast(1)) removeAllObjects];
+    [verifyCount(mockArray, eventuallyTimes(1)) removeAllObjects];
 }
 
-- (void)testAtLeastOnceInActionForExactCount
+- (void)testNeverInActionForExactCount
 {
     // given
     NSMutableArray *mockArray = mock([NSMutableArray class]);
 
     // when
-    [mockArray removeAllObjects];
+    // nothing
 
     // then
-    [verifyCount(mockArray, atLeastOnce()) removeAllObjects];
+    [verifyCount(mockArray, never()) removeAllObjects];
 }
 
-- (void)testEventuallyAtLeastOnceInActionForExactCount
+- (void)testEventuallyNeverInActionForExactCount
 {
     // given
     NSMutableArray *mockArray = mock([NSMutableArray class]);
 
     // when
-    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 50*NSEC_PER_MSEC);
-    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-        [mockArray removeAllObjects];
-    });
+    // nothing
 
     // then
-    [verifyCount(mockArray, eventuallyAtLeastOnce()) removeAllObjects];
+    [verifyCount(mockArray, eventuallyNever()) removeAllObjects];
 }
 
-- (void)testAtLeastInActionForExcessInvocations
-{
-    // given
-    NSMutableArray *mockArray = mock([NSMutableArray class]);
-    
-    // when
-    [mockArray addObject:@"foo"];
-    [mockArray addObject:@"foo"];
-    [mockArray addObject:@"foo"];
-    
-    // then
-    [verifyCount(mockArray, atLeast(2)) addObject:@"foo"];
-}
-
-- (void)testEventuallyAtLeastInActionForExcessInvocations
-{
-    // given
-    NSMutableArray *mockArray = mock([NSMutableArray class]);
-
-    // when
-    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 50*NSEC_PER_MSEC);
-    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-        [mockArray addObject:@"foo"];
-        [mockArray addObject:@"foo"];
-        [mockArray addObject:@"foo"];
-    });
-
-    // then
-    [verifyCount(mockArray, eventuallyAtLeast(2)) addObject:@"foo"];
-}
-
-- (void)testAtLeastOnceInActionForExcessInvocations
-{
-    // given
-    NSMutableArray *mockArray = mock([NSMutableArray class]);
-
-    // when
-    [mockArray addObject:@"foo"];
-    [mockArray addObject:@"foo"];
-
-    // then
-    [verifyCount(mockArray, atLeastOnce()) addObject:@"foo"];
-}
-
-- (void)testEventuallyAtLeastOnceInActionForExcessInvocations
-{
-    // given
-    NSMutableArray *mockArray = mock([NSMutableArray class]);
-
-    // when
-    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 50*NSEC_PER_MSEC);
-    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-        [mockArray addObject:@"foo"];
-        [mockArray addObject:@"foo"];
-    });
-
-    // then
-    [verifyCount(mockArray, eventuallyAtLeastOnce()) addObject:@"foo"];
-}
-
-- (void)testAtLeastInActionForTooLittleInvocations
+- (void)testTimesInActionForExcessInvocations
 {
     // given
     [self disableFailureHandler]; // enable the handler to catch the exception generated by verify()
     NSMutableArray *mockArray = mock([NSMutableArray class]);
-    
+
     // when
     [mockArray addObject:@"foo"];
-    
+    [mockArray addObject:@"foo"];
+    [mockArray addObject:@"foo"];
+
     // then
-    STAssertThrows(([verifyCount(mockArray, atLeast(2)) addObject:@"foo"]), @"verifyCount() should have failed");
+    STAssertThrows(([verifyCount(mockArray, times(2)) addObject:@"foo"]), @"verifyCount() should have failed");
 }
 
-- (void)testEventuallyAtLeastInActionForTooLittleInvocations
+- (void)testEventuallyTimesInActionForExcessInvocations
+{
+    // given
+    [self disableFailureHandler]; // enable the handler to catch the exception generated by verify()
+    NSMutableArray *mockArray = mock([NSMutableArray class]);
+
+    // when
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 500*NSEC_PER_MSEC);
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+        [mockArray addObject:@"foo"];
+        [mockArray addObject:@"foo"];
+        [mockArray addObject:@"foo"];
+    });
+
+    // then
+    STAssertThrows(([verifyCount(mockArray, eventuallyTimes(2)) addObject:@"foo"]), @"verifyCount() should have failed");
+}
+
+- (void)testNeverInActionForExcessInvocations
+{
+    // given
+    [self disableFailureHandler]; // enable the handler to catch the exception generated by verify()
+    NSMutableArray *mockArray = mock([NSMutableArray class]);
+
+    // when
+    [mockArray addObject:@"foo"];
+
+    // then
+    STAssertThrows(([verifyCount(mockArray, never()) addObject:@"foo"]), @"verifyCount() should have failed");
+}
+
+- (void)testEventuallyNeverInActionForExcessInvocations
+{
+    // given
+    [self disableFailureHandler]; // enable the handler to catch the exception generated by verify()
+    NSMutableArray *mockArray = mock([NSMutableArray class]);
+
+    // when
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 50*NSEC_PER_MSEC);
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+        [mockArray addObject:@"foo"];
+    });
+
+    // then
+    STAssertThrows(([verifyCount(mockArray, eventuallyNever()) addObject:@"foo"]), @"verifyCount() should have failed");
+}
+
+- (void)testTimesInActionForTooLittleInvocations
+{
+    // given
+    [self disableFailureHandler]; // enable the handler to catch the exception generated by verify()
+    NSMutableArray *mockArray = mock([NSMutableArray class]);
+
+    // when
+    [mockArray addObject:@"foo"];
+
+    // then
+    STAssertThrows(([verifyCount(mockArray, times(2)) addObject:@"foo"]), @"verifyCount() should have failed");
+}
+
+- (void)testEventuallyTimesInActionForTooLittleInvocations
 {
     // given
     [self disableFailureHandler]; // enable the handler to catch the exception generated by verify()
@@ -343,7 +342,7 @@
     });
 
     // then
-    STAssertThrows(([verifyCount(mockArray, eventuallyAtLeast(2)) addObject:@"foo"]), @"verifyCount() should have failed");
+    STAssertThrows(([verifyCount(mockArray, eventuallyTimes(2)) addObject:@"foo"]), @"verifyCount() should have failed");
 }
 
 

--- a/Source/Tests/MKTMockingProgressTest.m
+++ b/Source/Tests/MKTMockingProgressTest.m
@@ -84,7 +84,7 @@
 - (void)testPullVerificationModeWithVerificationStartedShouldReturnMode
 {
     // given
-    id <MKTVerificationMode> mode = [MKTExactTimes timesWithCount:42];
+    id <MKTVerificationMode> mode = [MKTExactTimes timesWithCount:42 eventually:NO];
     
     // when
     [mockingProgress verificationStarted:mode atLocation:MKTTestLocationMake(self, __FILE__, __LINE__)];
@@ -96,7 +96,7 @@
 - (void)testPullVerificationModeShouldClearCurrentVerification
 {
     // given
-    id <MKTVerificationMode> mode = [MKTExactTimes timesWithCount:42];
+    id <MKTVerificationMode> mode = [MKTExactTimes timesWithCount:42 eventually:NO];
     
     // when
     [mockingProgress verificationStarted:mode atLocation:MKTTestLocationMake(self, __FILE__, __LINE__)];


### PR DESCRIPTION
eventuallyTimes, eventuallyNever, eventuallyAtLeast and
eventuallyAtLeastOnce are the async version of their non-async
counterparts. They will "wait" a little for the check to
succeed or fail, instead of failing directly. This simplifies
async testing, where your system under test may be invoking blocks
in other queues asynchronously.