### PR TITLE
added capture of ^@ 

### DIFF
--- a/Source/OCMockito/NSInvocation+TKAdditions.m
+++ b/Source/OCMockito/NSInvocation+TKAdditions.m
@@ -98,6 +98,10 @@ NSArray *TKArrayArgumentsForInvocation(NSInvocation *invocation)
             void* arg;
             [invocation getArgument:&arg atIndex:i];
             [args insertObject:(__bridge id)(arg) atIndex:ai];
+        } else if (!strcmp(argType, @encode(typeof(NSObject **)))) {
+          void *arg;
+          [invocation getArgument:&arg atIndex:i];
+          [args insertObject:[NSValue valueWithPointer:arg] atIndex:ai];
         } else {
             NSCAssert1(NO, @"-- Unhandled type: %s", argType);
         }

--- a/Source/Tests/VerifyObjectTest.m
+++ b/Source/Tests/VerifyObjectTest.m
@@ -25,6 +25,7 @@
 
 @implementation TestObject
 - (void)methodWithClassArg:(Class)class { return; }
+- (id)methodWithError:(NSError **)error { return nil; }
 @end
 
 
@@ -214,6 +215,17 @@
     [testMock methodWithClassArg:[NSData class]];
     [verify(testMock) methodWithClassArg:[NSString class]];
     [verify(testMock) methodWithClassArg:[NSData class]];
+}
+
+- (void)testVerifyWithErrorArg
+{
+  // given
+  TestObject *testMock = mock([TestObject class]);
+	
+  [testMock methodWithError:NULL];
+  
+  [verify(testMock) methodWithError:NULL];
+	
 }
 
 @end


### PR DESCRIPTION
I had an unit test where I want to verify following method:

```
- (NSDictionary *)sendRequestWithParameters:(NSDictionary *)parameters error:(NSError **)error
```

and 

```
[verifyCount(serverRequest, never()) sendRequestWithParameters:(id) anything() error:nil];
```

This unit test did fail, because the NSError *\* was not capture and an "-- Unhandled type" exception was thrown. I have added that a NSObject*\* is captured which fixes this issue.
