### PR TITLE
Fixed crash capturing nil selectors as method parameters

### DIFF
--- a/Source/OCMockito/NSInvocation+TKAdditions.m
+++ b/Source/OCMockito/NSInvocation+TKAdditions.m
@@ -29,7 +29,7 @@ NSArray *TKArrayArgumentsForInvocation(NSInvocation *invocation)
         } else if(!strcmp(argType, @encode(SEL))) {
             SEL arg = nil;
             [invocation getArgument:&arg atIndex:i];
-            [args insertObject:NSStringFromSelector(arg) atIndex:ai];
+            [args insertObject:arg?NSStringFromSelector(arg):[NSNull null] atIndex:ai];
         } else if(!strcmp(argType, @encode(Class))) {
             __unsafe_unretained Class arg = nil;
             [invocation getArgument:&arg atIndex:i];

--- a/Source/Tests/VerifyObjectTest.m
+++ b/Source/Tests/VerifyObjectTest.m
@@ -26,6 +26,7 @@
 @implementation TestObject
 - (void)methodWithClassArg:(Class)class { return; }
 - (id)methodWithError:(NSError **)error { return nil; }
+- (void)methodWithSelector:(SEL)selector { return; }
 @end
 
 
@@ -234,5 +235,28 @@
   [verify(testMock) methodWithError:&error];
 }
 
+- (void)testVerifyWithNilSelectorArg
+{
+    // given
+    TestObject *testMock = mock([TestObject class]);
+    
+    // when
+    [testMock methodWithSelector:nil];
+    
+    // then
+    [verify(testMock) methodWithSelector:nil];
+}
+
+- (void)testVerifyWithNotNilSelectorArg
+{
+    // given
+    TestObject *testMock = mock([TestObject class]);
+    
+    // when
+    [testMock methodWithSelector:_cmd];
+    
+    // then
+    [verify(testMock) methodWithSelector:_cmd];
+}
 
 @end


### PR DESCRIPTION
Hi Jon!

This patch intends to fix this crash:

**\* -[__NSArrayM insertObject:atIndex:]: object cannot be nil

When a nil selector is passed as a parameter of a message sent to a mock object.

Regards
