### PR TITLE
Fix crash passing blocks to a mock method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Next version under development
 **Improvements:**
 
 - Added support for pointer arguments, including NSError **
-- Fix crash capturing nil selectors as method parameters. _Thanks to: Sergio PR_
+- Fix crash capturing nil selectors as method parameters. _Thanks to: Sergio Padrino_
 
 
 Version 1.1.0

--- a/Source/OCMockito/NSInvocation+TKAdditions.m
+++ b/Source/OCMockito/NSInvocation+TKAdditions.m
@@ -6,6 +6,7 @@
 
 #import "NSInvocation+TKAdditions.h"
 
+typedef void (^TKBlockType)(void);
 
 NSArray *TKArrayArgumentsForInvocation(NSInvocation *invocation)
 {
@@ -26,7 +27,15 @@ NSArray *TKArrayArgumentsForInvocation(NSInvocation *invocation)
         {
             __unsafe_unretained id arg = nil;
             [invocation getArgument:&arg atIndex:i];
-            [args insertObject:arg?arg:[NSNull null] atIndex:ai];
+            if (!strcmp(argType, @encode(TKBlockType)))
+            {
+                // Make sure blocks are copied
+                [args insertObject:(arg ? [arg copy] : [NSNull null]) atIndex:ai];
+            }
+            else
+            {
+                [args insertObject:(arg ? arg : [NSNull null]) atIndex:ai];
+            }
         }
         else if (strcmp(argType, @encode(SEL)) == 0)
         {


### PR DESCRIPTION
The purpose of this patch is fixing a EXC_BAD_ACCESS crash that occurs after running a test in which an inline block capturing a scope variable is passed as a method argument to a mock.

Example:

```
NSString *someVariable = @"hi";
MyClass *object = mock([MyClass class]);
[mock someMethodWithBlock:^{
    [someVariable doSomething];
}];
```

With a Deployment Target of iOS 5, the blocks are not copied, and therefore when the captured arguments are released, this block in the stack gets released more times than it should.
