### PR TITLE
Fixing an issue with stubs returning BOOL on 64bit iOS

### DIFF
--- a/Source/OCMockito/NSInvocation+TKAdditions.m
+++ b/Source/OCMockito/NSInvocation+TKAdditions.m
@@ -185,6 +185,11 @@ void MKTSetReturnValueForInvocation(NSInvocation *invocation, id returnValue)
         long long value = [returnValue longLongValue];
         [invocation setReturnValue:&value];
     }
+    else if(strcmp(returnType, @encode(BOOL)) == 0)
+    {
+        BOOL value = [returnValue boolValue];
+        [invocation setReturnValue:&value];
+    }
     else if (strcmp(returnType, @encode(unsigned char)) == 0)
     {
         unsigned char value = [returnValue unsignedCharValue];

--- a/Source/Tests/StubProtocolTest.m
+++ b/Source/Tests/StubProtocolTest.m
@@ -25,6 +25,7 @@
 - (id)methodReturningObject;
 - (id)methodReturningObjectWithArg:(id)arg;
 - (id)methodReturningObjectWithIntArg:(int)arg;
+- (BOOL)methodReturningBOOL;
 - (short)methodReturningShort;
 
 @end
@@ -87,6 +88,12 @@
     [[given([mockProtocol methodReturningObjectWithIntArg:0])
             withMatcher:greaterThan(@1)] willReturn:@"FOO"];
     assertThat([mockProtocol methodReturningObjectWithIntArg:2], is(@"FOO"));
+}
+
+- (void)testStubbedMethod_ShouldReturnGivenBool
+{
+    [given([mockProtocol methodReturningBOOL]) willReturnBool:YES];
+    assertThatBool([mockProtocol methodReturningBOOL], equalToBool(YES));
 }
 
 - (void)testStubbedMethod_ShouldReturnGivenShort


### PR DESCRIPTION
Looks like on 64bit iOS `@encode(BOOL)` results in `B` instead of `c` (as in 32bit iOS and Mac OS as well as _surprise surprise_ 64bit Mac OS).

Therefore `MKTSetReturnValueForInvocation` should have a dedicated check for `methodReturnType == @encode(BOOL)`.  
This check should be done after checking agains `@encode(char)` to not break char return types in non 64bit iOS.

Happy New Year
-ullrich

PS: I could reproduce this in my iOS7 only project, but unfortunately wasn't able to run the OCMockito test suite in 64bit, as my Xcode always decided to crash on trying so. I added a test for it anyway.
