### PR TITLE
Added support for dynamic properties

### DIFF
--- a/Source/OCMockito/MKTObjectAndProtocolMock.h
+++ b/Source/OCMockito/MKTObjectAndProtocolMock.h
@@ -6,15 +6,15 @@
 //  Source: https://github.com/jonreid/OCMockito
 //
 
-#import "MKTProtocolMock.h"
+#import "MKTObjectMock.h"
 
 
 /**
  Mock object of a given class that also implements a given protocol.
  */
-@interface MKTObjectAndProtocolMock : MKTProtocolMock
+@interface MKTObjectAndProtocolMock : MKTObjectMock
 
-+ (instancetype)mockForClass:(Class)aClass protocol:(Protocol *)protocol;
-- (instancetype)initWithClass:(Class)aClass protocol:(Protocol *)protocol;
++ (instancetype)mockForClass:(Class)aClass protocol:(Protocol *)aProtocol;
+- (instancetype)initWithClass:(Class)aClass protocol:(Protocol *)aProtocol;
 
 @end

--- a/Source/OCMockito/MKTObjectMock.m
+++ b/Source/OCMockito/MKTObjectMock.m
@@ -6,12 +6,16 @@
 //  Source: https://github.com/jonreid/OCMockito
 //
 
+#import <objc/runtime.h>
+
 #import "MKTObjectMock.h"
 
 
 @implementation MKTObjectMock
 {
     Class _mockedClass;
+
+    NSDictionary *_propertySelectors;
 }
 
 + (instancetype)mockForClass:(Class)aClass
@@ -23,8 +27,129 @@
 {
     self = [super init];
     if (self)
+    {
         _mockedClass = aClass;
+
+        NSMutableDictionary *propertySelectors = [[NSMutableDictionary alloc] init];
+
+        Class cls = aClass;
+        while (cls != [NSObject class] && cls != nil)
+        {
+
+            unsigned int outCount, i;
+            objc_property_t *properties = class_copyPropertyList(cls, &outCount);
+            for (i = 0; i < outCount; i++)
+            {
+                objc_property_t property = properties[i];
+
+                // Check if the property is dynamic (@dynamic).
+                char *dynamic = property_copyAttributeValue(property, "D");
+                if (dynamic)
+                {
+                    free(dynamic);
+
+                    [propertySelectors setObject:[self getGetterSignatureFor:property]
+                                          forKey:[self getGetterNameFor:property]];
+                    if (![self isReadonly:property])
+                    {
+                        [propertySelectors setObject:[self getSetterSignatureFor:property]
+                                              forKey:[self getSetterNameFor:property]];
+                    }
+                }
+            }
+            free(properties);
+
+            cls = [cls superclass];
+        }
+
+        _propertySelectors = propertySelectors;
+    }
+
     return self;
+}
+
+- (NSMethodSignature *)getSetterSignatureFor:(objc_property_t)aProperty
+{
+    NSString *typeString= [self getTypeString:aProperty];
+
+    return [NSMethodSignature signatureWithObjCTypes:
+            [[NSString stringWithFormat:@"v@:%@", typeString] UTF8String]];
+}
+
+- (id)getGetterSignatureFor:(objc_property_t)aProperty
+{
+    NSString *typeString= [self getTypeString:aProperty];
+
+    return [NSMethodSignature signatureWithObjCTypes:
+            [[NSString stringWithFormat:@"%@@:", typeString] UTF8String]];
+}
+
+- (NSString *)getTypeString:(objc_property_t)aProperty
+{
+    char *type = property_copyAttributeValue(aProperty, "T");
+    NSString * typeString = @"";
+    if (type) {
+        typeString = [NSString stringWithUTF8String:type];
+        free(type);
+    }
+    return typeString;
+}
+
+- (NSString *)getNameFor:(objc_property_t)aProperty
+{
+    return [NSString stringWithUTF8String:property_getName(aProperty)];
+}
+
+- (NSString *)getGetterNameFor:(objc_property_t)pProperty
+{
+    NSString *result;
+    char *getterName = property_copyAttributeValue(pProperty, "G");
+    if (getterName)
+    {
+        result = [NSString stringWithUTF8String:getterName];
+        free(getterName);
+    }
+    else
+    {
+        result = [self getNameFor:pProperty];
+    }
+
+    return result;
+}
+
+- (NSString *)getSetterNameFor:(objc_property_t)aProperty
+{
+    NSString *result;
+    char *setterName = property_copyAttributeValue(aProperty, "S");
+    if (setterName)
+    {
+        result = [NSString stringWithUTF8String:setterName];
+        free(setterName);
+    }
+    else
+    {
+        NSString *name = [self getNameFor:aProperty];
+        name = [name stringByReplacingCharactersInRange:NSMakeRange(0, 1)
+                                             withString:[[name substringToIndex:1] uppercaseString]];
+        result = [NSString stringWithFormat:@"set%@:", name];
+    }
+
+    return result;
+}
+
+- (BOOL)isReadonly:(objc_property_t)aProperty
+{
+    char *readonly = property_copyAttributeValue(aProperty, "R");
+
+    if (readonly)
+    {
+        free(readonly);
+        return YES;
+    }
+    else
+    {
+        return NO;
+    }
 }
 
 - (NSString *)description
@@ -34,7 +159,12 @@
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
 {
-    return [_mockedClass instanceMethodSignatureForSelector:aSelector];
+    NSMethodSignature *signature = [_propertySelectors objectForKey:NSStringFromSelector(aSelector)];
+
+    if (signature)
+        return signature;
+    else
+        return [_mockedClass instanceMethodSignatureForSelector:aSelector];
 }
 
 
@@ -47,7 +177,8 @@
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
-    return [_mockedClass instancesRespondToSelector:aSelector];
+    return [_propertySelectors objectForKey:NSStringFromSelector(aSelector)] ||
+            [_mockedClass instancesRespondToSelector:aSelector];
 }
 
 @end

--- a/Source/OCMockito/MKTProtocolMock.h
+++ b/Source/OCMockito/MKTProtocolMock.h
@@ -13,9 +13,6 @@
  Mock object implementing a given protocol.
  */
 @interface MKTProtocolMock : MKTBaseMockObject
-{
-    Protocol *_mockedProtocol;
-}
 
 + (instancetype)mockForProtocol:(Protocol *)aProtocol;
 - (instancetype)initWithProtocol:(Protocol *)aProtocol;

--- a/Source/OCMockito/MKTProtocolMock.m
+++ b/Source/OCMockito/MKTProtocolMock.m
@@ -12,6 +12,9 @@
 
 
 @implementation MKTProtocolMock
+{
+    Protocol *_mockedProtocol;
+}
 
 + (instancetype)mockForProtocol:(Protocol *)aProtocol
 {
@@ -39,7 +42,7 @@
         methodDescription = protocol_getMethodDescription(_mockedProtocol, aSelector, NO, YES);
     if (!methodDescription.name)
         return nil;
-	return [NSMethodSignature signatureWithObjCTypes:methodDescription.types];
+    return [NSMethodSignature signatureWithObjCTypes:methodDescription.types];
 }
 
 

--- a/Source/Tests/MKTObjectAndProtocolMockTest.m
+++ b/Source/Tests/MKTObjectAndProtocolMockTest.m
@@ -26,19 +26,23 @@
 @end
 
 
-@interface TestClass : NSObject 
+@interface TestClass : NSObject
+@property (nonatomic) NSString* stringProperty;
 - (void)instanceMethod;
 @end
 
 @implementation TestClass
+@dynamic stringProperty;
 - (void)instanceMethod {}
 @end
 
 
 @interface TestSubclass : TestClass <TestProtocol>
+@property (nonatomic) NSString* nonDynamicStringProperty;
 @end
 
 @implementation TestSubclass
+@synthesize nonDynamicStringProperty;
 - (void)requiredMethod {}
 @end
 
@@ -123,6 +127,34 @@
 - (void)testMock_ShouldRespondToRequiredSelector
 {
     STAssertTrue([mock respondsToSelector:@selector(requiredMethod)], nil);
+}
+
+- (void)testMock_ShouldRespondToDynamicSetterSelector
+{
+    STAssertTrue([mock respondsToSelector:@selector(setStringProperty:)], nil);
+}
+
+- (void)testMock_ShouldRespondToDynamicGetterSelector
+{
+    STAssertTrue([mock respondsToSelector:@selector(stringProperty)], nil);
+}
+
+- (void)testMock_ShouldAnswerSameMethodSignatureForRequiredSelectorForGetter
+{
+    TestClass<TestProtocol> *obj = [[TestSubclass alloc] init];
+    SEL selector = @selector(nonDynamicStringProperty);
+
+    NSMethodSignature *signature = [mock methodSignatureForSelector:@selector(stringProperty)];
+    assertThat(signature, equalTo([obj methodSignatureForSelector:selector]));
+}
+
+- (void)testMock_ShouldAnswerSameMethodSignatureForRequiredSelectorForSetter
+{
+    TestClass<TestProtocol> *obj = [[TestSubclass alloc] init];
+    SEL selector = @selector(setNonDynamicStringProperty:);
+
+    NSMethodSignature *signature = [mock methodSignatureForSelector:@selector(setStringProperty:)];
+    assertThat(signature, equalTo([obj methodSignatureForSelector:selector]));
 }
 
 @end

--- a/Source/Tests/MKTObjectMockTest.m
+++ b/Source/Tests/MKTObjectMockTest.m
@@ -20,18 +20,55 @@
 #endif
 
 
+@interface PropertyHolder : NSObject
+
+@property (nonatomic) NSString* myProperty;
+
+@end
+
+@implementation PropertyHolder
+
+@dynamic myProperty;
+
+@end
+
+@interface CustomPropertyHolder : NSObject
+
+@property (nonatomic, getter = getMyCustomProperty, setter = setterMyCustomProperty:) NSString* myCustomProperty;
+
+@end
+
+@implementation CustomPropertyHolder
+
+@dynamic myCustomProperty;
+
+@end
+
+@interface StringPropertyHolder : NSObject
+@property (nonatomic) NSString* stringProperty;
+@end
+
+@implementation StringPropertyHolder
+@synthesize stringProperty;
+@end
+
 @interface MKTObjectMockTest : SenTestCase
 @end
 
 @implementation MKTObjectMockTest
 {
     NSString *mockString;
+    PropertyHolder *mockDynamicPropertyHolder;
+    CustomPropertyHolder *mockDynamicCustomPropertyHolder;
 }
 
 - (void)setUp
 {
     [super setUp];
+
     mockString = mock([NSString class]);
+    mockDynamicPropertyHolder = mock([PropertyHolder class]);
+    mockDynamicCustomPropertyHolder = mock([CustomPropertyHolder class]);
 }
 
 - (void)testDescription
@@ -78,6 +115,44 @@
 - (void)testMock_ShouldNotRespondToUnknownSelector
 {
     STAssertFalse([mockString respondsToSelector:@selector(removeAllObjects)], nil);
+}
+
+- (void)testMock_ShouldRespondToDynamicSetterSelector
+{
+    STAssertTrue([mockDynamicPropertyHolder respondsToSelector:@selector(setMyProperty:)], nil);
+}
+
+- (void)testMock_ShouldRespondToDynamicGetterSelector
+{
+    STAssertTrue([mockDynamicPropertyHolder respondsToSelector:@selector(myProperty)], nil);
+}
+
+- (void)testMock_ShouldRespondToDynamicSetterSelectorWithCustomName
+{
+    STAssertTrue([mockDynamicCustomPropertyHolder respondsToSelector:@selector(setterMyCustomProperty:)], nil);
+}
+
+- (void)testMock_ShouldRespondToDynamicGetterSelectorWithCustomName
+{
+    STAssertTrue([mockDynamicCustomPropertyHolder respondsToSelector:@selector(getMyCustomProperty)], nil);
+}
+
+- (void)testMock_ShouldAnswerSameMethodSignatureForRequiredSelectorForGetter
+{
+    StringPropertyHolder *obj = [[StringPropertyHolder alloc] init];
+    SEL selector = @selector(stringProperty);
+
+    NSMethodSignature *signature = [mockDynamicPropertyHolder methodSignatureForSelector:@selector(myProperty)];
+    assertThat(signature, equalTo([obj methodSignatureForSelector:selector]));
+}
+
+- (void)testMock_ShouldAnswerSameMethodSignatureForRequiredSelectorForSetter
+{
+    StringPropertyHolder *obj = [[StringPropertyHolder alloc] init];
+    SEL selector = @selector(setStringProperty:);
+    
+    NSMethodSignature *signature = [mockDynamicPropertyHolder methodSignatureForSelector:@selector(setMyProperty:)];
+    assertThat(signature, equalTo([obj methodSignatureForSelector:selector]));
 }
 
 @end


### PR DESCRIPTION
Patch for issue #63 

Added tracking/creating inovcations for dynamic properties
The contribution based on the Tobias Krantzer's blog post - https://tobias-kraentzer.de/2013/05/15/dynamic-properties-in-objective-c/ and code - https://github.com/anagromataf/DynamicProperties

The main intention was to easily use Core Data mock object in tests. Let me know if these changes are redundant. I've tried to follow code convection style as well I've tried to cover new functionality with unit tests.

I'm new to obj-c development so please review changes carefully. Thank you!
