### PR TITLE
Added macro to stub properties that work with sort descriptors, predicates etc

### DIFF
--- a/Source/OCMockito/OCMockito.h
+++ b/Source/OCMockito/OCMockito.h
@@ -88,6 +88,16 @@ FOUNDATION_EXPORT MKTOngoingStubbing *MKTGivenWithLocation(id testCase, const ch
     #define given(methodCall) MKTGiven(methodCall)
 #endif
 
+#define MKTStubProperty(instance, property, value) ({\
+    [given([instance property]) willReturn:value];\
+    [given([instance valueForKeyPath:@#property]) willReturn:value];\
+    [given([instance valueForKey:@#property]) willReturn:value];\
+})
+
+#ifdef MOCKITO_SHORTHAND
+    #define stubProperty(instance, property, value) MKTStubProperty(instance, property, value)
+#endif
+
 
 FOUNDATION_EXPORT id MKTVerifyWithLocation(id mock, id testCase, const char *fileName, int lineNumber);
 #define MKTVerify(mock) MKTVerifyWithLocation(mock, self, __FILE__, __LINE__)

--- a/Source/Tests/StubObjectTest.m
+++ b/Source/Tests/StubObjectTest.m
@@ -32,6 +32,11 @@ static inline double *createArrayOf10Doubles(void)
     return malloc(10*sizeof(double));
 }
 
+@interface PropertyObject : NSObject
+@property (nonatomic, assign) NSUInteger integerValue;
+@end
+@implementation PropertyObject
+@end
 
 @interface ReturningObject : NSObject
 @end
@@ -297,6 +302,62 @@ static inline double *createArrayOf10Doubles(void)
 {
     [given([mockObject methodReturningDouble]) willReturnDouble:42];
     assertThatDouble([mockObject methodReturningDouble], equalToDouble(42));
+}
+
+- (void)testGivenProperty_DoesntWorkWithPredicate
+{
+    PropertyObject *obj = mock([PropertyObject class]);
+    [given([obj integerValue]) willReturn:@42];
+    assertThatUnsignedInteger([obj integerValue], equalToUnsignedInteger(42));
+    
+    NSArray *array = @[ obj ];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"integerValue == 42"];
+    array = [array filteredArrayUsingPredicate:predicate];
+    assertThat(array, isEmpty());
+}
+
+- (void)testGivenProperty_DoesntWorkWithSortDescriptor
+{
+    NSMutableArray *sortedArray = [NSMutableArray array];
+    NSMutableSet *set = [NSMutableSet set];
+    for (NSUInteger i = 0; i < 100; ++i) {
+        PropertyObject *obj = mock([PropertyObject class]);
+        [given([obj integerValue]) willReturn:@(i)];
+        [set addObject:obj];
+        [sortedArray addObject:obj];
+    }
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"integerValue"
+                                                                     ascending:YES];
+    NSArray *array = [set sortedArrayUsingDescriptors:@[sortDescriptor]];
+    assertThat(sortedArray, isNot(equalTo(array)));
+}
+
+- (void)testStubProperty_WorksWithPredicate
+{
+    PropertyObject *obj = mock([PropertyObject class]);
+    stubProperty(obj, integerValue, @42);
+    assertThatUnsignedInteger([obj integerValue], equalToUnsignedInteger(42));
+    
+    NSArray *array = @[ obj ];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"integerValue == 42"];
+    array = [array filteredArrayUsingPredicate:predicate];
+    assertThat(array, hasCountOf(1));
+}
+
+- (void)testStubProperty_WorksWithSortDescriptor
+{
+    NSMutableArray *sortedArray = [NSMutableArray array];
+    NSMutableSet *set = [NSMutableSet set];
+    for (NSUInteger i = 0; i < 100; ++i) {
+        PropertyObject *obj = mock([PropertyObject class]);
+        stubProperty(obj, integerValue, @(i));
+        [set addObject:obj];
+        [sortedArray addObject:obj];
+    }
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"integerValue"
+                                                                     ascending:YES];
+    NSArray *array = [set sortedArrayUsingDescriptors:@[sortDescriptor]];
+    assertThat(sortedArray, equalTo(array));
 }
 
 @end


### PR DESCRIPTION
I ran into the following issue: when stubbing a property value using 

``` objective-c
[given([obj someProperty]) willReturn:@42)];
```

it doesn't work with `NSSortDescriptor` or `NSPredicate` and some other API that relies on `valueForKey:` and `valueForKeyPath:` instead of direct querying the properties.

That's why I added a small macro `stubProperty` (or `MKTStubProperty`) to address this issue. Please let me know what do you think of this implementation.

Also added some tests to illustrate the issue. Tests showing that `given(…)` stubbing approach is not working in this case might be redundant.
