### PR TITLE
Support for optional and required methods in MTKProtocolMock

### DIFF
--- a/Source/OCMockito/MKTProtocolMock.h
+++ b/Source/OCMockito/MKTProtocolMock.h
@@ -10,8 +10,12 @@
 @interface MKTProtocolMock : MKTBaseMockObject
 
 @property (readonly, nonatomic, strong) Protocol *mockedProtocol;
+@property (readonly, nonatomic) BOOL includeOptionalMethods;
 
 + (instancetype)mockForProtocol:(Protocol *)aProtocol;
++ (instancetype)mockForProtocol:(Protocol *)aProtocol includeOptionalMethods:(BOOL)includeOptionalMethods;
+
 - (instancetype)initWithProtocol:(Protocol *)aProtocol;
+- (instancetype)initWithProtocol:(Protocol *)aProtocol includeOptionalMethods:(BOOL)includeOptionalMethods;
 
 @end

--- a/Source/OCMockito/MKTProtocolMock.m
+++ b/Source/OCMockito/MKTProtocolMock.m
@@ -8,16 +8,27 @@
 
 @implementation MKTProtocolMock
 
-+ (instancetype)mockForProtocol:(Protocol *)aProtocol
-{
-    return [[self alloc] initWithProtocol:aProtocol];
++ (instancetype)mockForProtocol:(Protocol *)aProtocol {
+    return [self mockForProtocol:aProtocol includeOptionalMethods:YES];
 }
 
-- (instancetype)initWithProtocol:(Protocol *)aProtocol
++ (instancetype)mockForProtocol:(Protocol *)aProtocol includeOptionalMethods:(BOOL)includeOptionalMethods
+{
+    return [[self alloc] initWithProtocol:aProtocol includeOptionalMethods:includeOptionalMethods];
+}
+
+- (instancetype)initWithProtocol:(Protocol *)aProtocol {
+    return [self initWithProtocol:aProtocol includeOptionalMethods:YES];
+}
+
+- (instancetype)initWithProtocol:(Protocol *)aProtocol includeOptionalMethods:(BOOL)includeOptionalMethods
 {
     self = [super init];
-    if (self)
+    if (self) {
         _mockedProtocol = aProtocol;
+        _includeOptionalMethods = includeOptionalMethods;
+    }
+    
     return self;
 }
 
@@ -31,13 +42,12 @@
 {
     struct objc_method_description methodDescription =
             protocol_getMethodDescription(self.mockedProtocol, aSelector, YES, YES);
-    if (!methodDescription.name)
+    if (!methodDescription.name && self.includeOptionalMethods)
         methodDescription = protocol_getMethodDescription(self.mockedProtocol, aSelector, NO, YES);
     if (!methodDescription.name)
         return nil;
     return [NSMethodSignature signatureWithObjCTypes:methodDescription.types];
 }
-
 
 #pragma mark NSObject protocol
 

--- a/Source/Tests/MKTProtocolMockTests.m
+++ b/Source/Tests/MKTProtocolMockTests.m
@@ -101,6 +101,27 @@
     assertThat(signature, is(nilValue()));
 }
 
+- (void)testWhenOptionalMethodsAreNotIncludedShouldNotAnswerSignatureSelectorAsRealImplementer {
+    mockImplementer = (id<TestingProtocol>)[MKTProtocolMock mockForProtocol:@protocol(TestingProtocol) includeOptionalMethods:NO];
+
+    SEL sel = @selector(optional);
+
+    NSMethodSignature *signature = [(id) mockImplementer methodSignatureForSelector:sel];
+
+    assertThat(signature, equalTo(nil));
+}
+
+- (void)testWhenOptionalMethodsArIncludedShouldAnswerSignatureSelectorAsRealImplementer {
+    mockImplementer = (id<TestingProtocol>)[MKTProtocolMock mockForProtocol:@protocol(TestingProtocol) includeOptionalMethods:YES];
+
+    PartialImplementer *realImplementer = [[PartialImplementer alloc] init];
+    SEL sel = @selector(optional);
+
+    NSMethodSignature *signature = [(id) mockImplementer methodSignatureForSelector:sel];
+
+    assertThat(signature, equalTo([realImplementer methodSignatureForSelector:sel]));
+}
+
 - (void)testShouldConformToItsOwnProtocol
 {
     STAssertTrue([mockImplementer conformsToProtocol:@protocol(TestingProtocol)], nil);


### PR DESCRIPTION
This small PR adds a simple support for not implementing optional methods in `MKTProtocolMock`. Backwards compatible and covered with tests :wink: 
