### PR TITLE
Remove version specific framework search path

### DIFF
--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -2714,7 +2714,8 @@
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SRCROOT)\"",
-					"\"$(SRCROOT)/../Frameworks/OCHamcrest-5.1.0\"",
+					"\"$(SRCROOT)/../Frameworks/\"/**",
+					"\"$(SRCROOT)/../Carthage/\"/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
@@ -2740,7 +2741,8 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SRCROOT)\"",
-					"\"$(SRCROOT)/../Frameworks/OCHamcrest-5.1.0\"",
+					"\"$(SRCROOT)/../Frameworks/\"/**",
+					"\"$(SRCROOT)/../Carthage/\"/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;


### PR DESCRIPTION
When running carthage update, building OCMockito results in the following:

`ld: warning: directory not found for option '-F/<removed>/Carthage/Checkouts/OCMockito/Source/../Frameworks/OCHamcrest-5.1.0'`

Replacing it with more general paths resolves this warning.

Installing via Cocoapods worked after this change; however, I haven't tested install methods other than Carthage and Cocoapods.