### PR TITLE
Fix framework search path for carthage dependencies

### DIFF
--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -2715,7 +2715,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SRCROOT)\"",
 					"\"$(SRCROOT)/../Frameworks/\"/**",
-					"\"$(SRCROOT)/../Carthage/\"/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
@@ -2742,7 +2741,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SRCROOT)\"",
 					"\"$(SRCROOT)/../Frameworks/\"/**",
-					"\"$(SRCROOT)/../Carthage/\"/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;


### PR DESCRIPTION
Remove framework search path for carthage dependencies from the project build settings and only stick to the target build settings to not mess up with the different architectures.

Fixes #119 