### PR TITLE
Update ARC rules based on “Basic Memory Management Rules” 

### DIFF
--- a/Source/OCMockito/Stubbing/MKTInvocationContainer.h
+++ b/Source/OCMockito/Stubbing/MKTInvocationContainer.h
@@ -18,6 +18,6 @@
 - (void)setMatcher:(id <HCMatcher>)matcher atIndex:(NSUInteger)argumentIndex;
 - (void)addAnswer:(id <MKTAnswer>)answer;
 - (MKTStubbedInvocationMatcher *)findAnswerFor:(NSInvocation *)invocation;
-- (BOOL)isStubbingCopyMethod;
+- (BOOL)isStubbingOwnedObjectMethod;
 
 @end

--- a/Source/OCMockito/Stubbing/MKTInvocationContainer.m
+++ b/Source/OCMockito/Stubbing/MKTInvocationContainer.m
@@ -12,7 +12,7 @@
 @property (nonatomic, strong, readonly) NSMutableArray *mutableRegisteredInvocations;
 @property (nonatomic, strong) MKTStubbedInvocationMatcher *invocationForStubbing;
 @property (nonatomic, strong, readonly) NSMutableArray *stubbed;
-@property (nonatomic, strong, readonly) NSArray<NSString *> *ownedObjectMethodPrefixes;
+@property (nonatomic, strong, readonly) NSArray *ownedObjectMethodPrefixes;
 @end
 
 @implementation MKTInvocationContainer

--- a/Source/OCMockito/Stubbing/MKTInvocationContainer.m
+++ b/Source/OCMockito/Stubbing/MKTInvocationContainer.m
@@ -12,6 +12,7 @@
 @property (nonatomic, strong, readonly) NSMutableArray *mutableRegisteredInvocations;
 @property (nonatomic, strong) MKTStubbedInvocationMatcher *invocationForStubbing;
 @property (nonatomic, strong, readonly) NSMutableArray *stubbed;
+@property (nonatomic, strong, readonly) NSArray<NSString *> *ownedObjectMethodPrefixes;
 @end
 
 @implementation MKTInvocationContainer
@@ -24,6 +25,12 @@
     {
         _mutableRegisteredInvocations = [[NSMutableArray alloc] init];
         _stubbed = [[NSMutableArray alloc] init];
+        _ownedObjectMethodPrefixes = @[
+                                       NSStringFromSelector(@selector(alloc)),
+                                       NSStringFromSelector(@selector(new)),
+                                       NSStringFromSelector(@selector(copy)),
+                                       NSStringFromSelector(@selector(mutableCopy)),
+                                       ];
     }
     return self;
 }
@@ -65,10 +72,22 @@
     return nil;
 }
 
-- (BOOL)isStubbingCopyMethod
+- (BOOL)isStubbingOwnedObjectMethod
 {
-    return self.registeredInvocations.count > 0 &&
-            [self.registeredInvocations[0] invocation].selector == @selector(copy);
+    NSInvocation *invocation = [self.registeredInvocations.firstObject invocation];
+    SEL selector = invocation.selector;
+    if (selector == 0) {
+        return NO;
+    }
+
+    NSString *selectorName = NSStringFromSelector(selector);
+    for (NSString *ownedObjectMethodPrefix in self.ownedObjectMethodPrefixes) {
+        if ([selectorName hasPrefix:ownedObjectMethodPrefix]) {
+            return YES;
+        }
+    }
+    
+    return NO;
 }
 
 @end

--- a/Source/OCMockito/Stubbing/MKTOngoingStubbing.m
+++ b/Source/OCMockito/Stubbing/MKTOngoingStubbing.m
@@ -27,8 +27,8 @@
 
 - (MKTOngoingStubbing *)willReturn:(id)object
 {
-    // Workaround for over-releasing mock object that is stubbed as return value for copy method.
-    if (self.invocationContainer.isStubbingCopyMethod && [MKTBaseMockObject isMockObject:object])
+    // Workaround for over-releasing mock object that is stubbed as return value for an owned object method.
+    if (self.invocationContainer.isStubbingOwnedObjectMethod && [MKTBaseMockObject isMockObject:object])
         CFBridgingRetain(object);
 
     MKTReturnsValue *returnsValue = [[MKTReturnsValue alloc] initWithValue:object];

--- a/Source/Tests/StubbingCopyTests.m
+++ b/Source/Tests/StubbingCopyTests.m
@@ -6,38 +6,119 @@
 #import <OCHamcrest/OCHamcrest.h>
 #import <XCTest/XCTest.h>
 
-
-@interface CopyingClass : NSObject
-@property (nonatomic, copy, readonly) NSURL *url;
-- (instancetype)initWithURL:(NSURL *)url;
+@interface InjectedClass : NSObject
++ (id)alloccurrences;
++ (id)newspaper;
+- (id)alloccurrences;
+- (id)newspaper;
+- (id)copyThisObject;
+- (id)mutableCopyThisObject;
 @end
 
-@implementation CopyingClass
+@implementation InjectedClass
 
-- (instancetype)initWithURL:(NSURL *)url
++ (id)alloccurrences
+{
+    return [self new];
+}
+
++ (id)newspaper
+{
+    return [self new];
+}
+
+- (id)alloccurrences
+{
+    return self;
+}
+
+- (id)newspaper
+{
+    return self;
+}
+
+- (id)copyThisObject
+{
+    return [self copy];
+}
+
+- (id)mutableCopyThisObject
+{
+    return [self mutableCopy];
+}
+
+@end
+
+
+@interface InjectingClass : NSObject
+@property (nonatomic, copy, readonly) InjectingClass *response1;
+@property (nonatomic, copy, readonly) InjectingClass *response2;
+@property (nonatomic, copy, readonly) InjectingClass *response3;
+@property (nonatomic, copy, readonly) InjectingClass *response4;
+@property (nonatomic, copy, readonly) InjectingClass *response5;
+@property (nonatomic, copy, readonly) InjectingClass *response6;
+@property (nonatomic, copy, readonly) InjectingClass *response7;
+@property (nonatomic, copy, readonly) InjectingClass *response8;
+- (instancetype)initWithInjectedClass:(InjectedClass *)injectedClass;
+@end
+
+@implementation InjectingClass
+
+- (instancetype)initWithInjectedClass:(InjectedClass *)injectedClass
 {
     self = [super init];
-    if (self)
-        _url = [url copy];
+    if (self) {
+        _response1 = [InjectedClass alloccurrences];
+        _response2 = [InjectedClass newspaper];
+        _response3 = [injectedClass alloccurrences];
+        _response4 = [injectedClass newspaper];
+        _response5 = [injectedClass copy];
+        _response6 = [injectedClass copyThisObject];
+        _response7 = [injectedClass mutableCopy];
+        _response8 = [injectedClass mutableCopyThisObject];
+    }
+
     return self;
 }
 
 @end
 
 
-@interface StubbingCopyTests : XCTestCase
+@interface StubbingOwnedObjectMethodTests : XCTestCase
 @end
 
-@implementation StubbingCopyTests
+@implementation StubbingOwnedObjectMethodTests
 
-- (void)testCopyingWithCopyExpectation
+- (void)testOwnedObjectInstanceMethods
 {
-    NSURL *mockUrl = mock([NSURL class]);
-    [given([mockUrl copy]) willReturn:mockUrl];
-    
-    CopyingClass *copyingClass = [[CopyingClass alloc] initWithURL:mockUrl];
-    
-    assertThat(copyingClass.url, is(sameInstance(mockUrl)));
+    @autoreleasepool {
+        InjectedClass *objectMock = mock([InjectedClass class]);
+        [given([objectMock alloccurrences]) willReturn:objectMock];
+        [given([objectMock newspaper]) willReturn:objectMock];
+        [given([objectMock copy]) willReturn:objectMock];
+        [given([objectMock copyThisObject]) willReturn:objectMock];
+        [given([objectMock mutableCopy]) willReturn:objectMock];
+        [given([objectMock mutableCopyThisObject]) willReturn:objectMock];
+        
+        __strong Class classMock = mockClass([InjectedClass class]);
+        stubSingleton(classMock, alloccurrences);
+        stubSingleton(classMock, newspaper);
+        [given ([InjectedClass alloccurrences]) willReturn:objectMock];
+        [given ([InjectedClass newspaper]) willReturn:objectMock];
+
+        InjectingClass *codeUnderTest = [[InjectingClass alloc] initWithInjectedClass:objectMock];
+        
+        assertThat(codeUnderTest.response1, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response2, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response3, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response4, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response5, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response6, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response7, is(sameInstance(objectMock)));
+        assertThat(codeUnderTest.response8, is(sameInstance(objectMock)));
+        
+        stopMocking(objectMock);
+    }
 }
 
 @end


### PR DESCRIPTION
The problem with copy stems from the ARC rules documented under "Basic Memory Management Rules" at https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html

I suspect the problem is that we're calling `copy` on an `NSProxy`, so we need to explicitly `retain` the returned object in this case. I assume that this is automatically taken care of in the `NSObject` implementation.

As such, we should be performing this logic on all method names that start with `alloc`, `new`, `copy` and `mutableCopy`. I rewrote the test using the method name `copyThisObject` and saw the same crash before the attached fix.