### PR TITLE
Stub singleton weak ref fix

### DIFF
--- a/Source/OCMockito/Mocking/MKTSingletonSwizzler.m
+++ b/Source/OCMockito/Mocking/MKTSingletonSwizzler.m
@@ -21,6 +21,7 @@ static NSString *singletonKey(Class aClass, SEL aSelector)
 @property (nonatomic, weak, readonly) Class mockedClass;
 @property (nonatomic, assign, readonly) IMP oldIMP;
 @property (nonatomic, assign, readonly) SEL selector;
+@property (nonatomic, assign, readonly) void *mockPtr;
 @end
 
 @implementation MKTSingletonMapEntry
@@ -31,6 +32,7 @@ static NSString *singletonKey(Class aClass, SEL aSelector)
     if (self)
     {
         _mock = mock;
+        _mockPtr = (__bridge void*)mock;
         _mockedClass = mock.mockedClass;
         _oldIMP = oldIMP;
         _selector = aSelector;
@@ -40,9 +42,9 @@ static NSString *singletonKey(Class aClass, SEL aSelector)
 
 - (BOOL)isForMock:(MKTClassObjectMock *)theMock
 {
-    // At time of dealloc, it's possible the weak ref to self.mock is nil,
-    // so we also check directly on the ivar.
-    return self.mock == theMock || self->_mock == theMock;
+    // At time of dealloc, it's possible the weak ref to self.mock returns nil,
+    // so only a pointer comparison is guaranteed to return YES
+    return self.mockPtr == (__bridge void *)theMock;
 }
 
 - (void)unswizzleSingleton


### PR DESCRIPTION
Jon, I have ran into the issue again, where it intermittently does not work with that mock comparison in the if statement. So, I think comparing pointers ought to reliably work. Let me know if you would like to discuss further. It's happening for some of us, and not for some others (it may depend on the LLVM used).

I think I got a working solution now. The mock comparison was not enough. Sometimes, it was comparing nil == nil, which would be true, but not what we wanted (because self.mock was nullified and the parameter theMock was also nil. I worked around this by creating a 'tag' of the mock, using it's pointer (hence the _mockPtr) ivar. That can be assigned at construction and won't get changed by ARC's weak refs. We are not de-referencing it anywhere, so it's safe. We're just comparing to see if we should unswizzle on dealloc.