### PR TITLE
Separate stopMocking() into disableMocking() and stopMocking()

### DIFF
--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -646,6 +646,10 @@
 		638F68D8150FC21A0081DEE6 /* MKTClassObjectMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 638F68D5150FC21A0081DEE6 /* MKTClassObjectMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		638F68D9150FC21A0081DEE6 /* MKTClassObjectMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */; };
 		638F68DA150FC21A0081DEE6 /* MKTClassObjectMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */; };
+		65EEDE271E1D327600463068 /* DisableMockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE261E1D327600463068 /* DisableMockingTests.m */; };
+		65EEDE2A1E1D337400463068 /* ObservableObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE291E1D337400463068 /* ObservableObject.m */; };
+		65EEDF231E1D389B00463068 /* DisableMockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE261E1D327600463068 /* DisableMockingTests.m */; };
+		65EEDF241E1D38F400463068 /* ObservableObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE291E1D337400463068 /* ObservableObject.m */; };
 		740018631A58E1BD00E9AC92 /* MKTReturnsValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 740018611A58E1BD00E9AC92 /* MKTReturnsValue.h */; };
 		740018641A58E1BD00E9AC92 /* MKTReturnsValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 740018611A58E1BD00E9AC92 /* MKTReturnsValue.h */; };
 		740018651A58E1BD00E9AC92 /* MKTReturnsValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 740018621A58E1BD00E9AC92 /* MKTReturnsValue.m */; };
@@ -1016,6 +1020,9 @@
 		638F68D5150FC21A0081DEE6 /* MKTClassObjectMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTClassObjectMock.h; sourceTree = "<group>"; };
 		638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTClassObjectMock.m; sourceTree = "<group>"; };
 		638F68DC150FC3210081DEE6 /* MKTClassObjectMockTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTClassObjectMockTests.m; sourceTree = "<group>"; };
+		65EEDE261E1D327600463068 /* DisableMockingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DisableMockingTests.m; sourceTree = "<group>"; };
+		65EEDE281E1D337400463068 /* ObservableObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObservableObject.h; sourceTree = "<group>"; };
+		65EEDE291E1D337400463068 /* ObservableObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObservableObject.m; sourceTree = "<group>"; };
 		740018611A58E1BD00E9AC92 /* MKTReturnsValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTReturnsValue.h; sourceTree = "<group>"; };
 		740018621A58E1BD00E9AC92 /* MKTReturnsValue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTReturnsValue.m; sourceTree = "<group>"; };
 		740018671A58E1E400E9AC92 /* MKTAnswer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTAnswer.h; sourceTree = "<group>"; };
@@ -1237,6 +1244,8 @@
 				609E9ECEDA1F0A719513AAC4 /* DummyObject.m */,
 				609E9D120E577A372AE36EAA /* FakeLocation.h */,
 				609E9BDCD18394B0FFD08C75 /* FakeLocation.m */,
+				65EEDE281E1D337400463068 /* ObservableObject.h */,
+				65EEDE291E1D337400463068 /* ObservableObject.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1442,6 +1451,7 @@
 				08E9DC271516739A00BD7FB4 /* MKTObjectAndProtocolMockTests.m */,
 				085A8BC6150718E30018EC66 /* MKTProtocolMockTests.m */,
 				609E9F142955F412A8AFE0AD /* StopMockingTests.m */,
+				65EEDE261E1D327600463068 /* DisableMockingTests.m */,
 			);
 			name = Mocking;
 			sourceTree = "<group>";
@@ -2619,8 +2629,10 @@
 				74A3BD9D19F767AD006591C9 /* MKTObjectAndProtocolMockTests.m in Sources */,
 				74A3BDA119F767AD006591C9 /* BlockMatchingTests.m in Sources */,
 				74A3BD9E19F767AD006591C9 /* MKTProtocolMockTests.m in Sources */,
+				65EEDE2A1E1D337400463068 /* ObservableObject.m in Sources */,
 				74A3BDA219F767B8006591C9 /* MockTestCase.m in Sources */,
 				0EEDEB021C0949AF0078A8F0 /* MKTAtLeastNumberOfInvocationsCheckerTests.m in Sources */,
+				65EEDE271E1D327600463068 /* DisableMockingTests.m in Sources */,
 				74A3BDA819F767B8006591C9 /* VerifyProtocolTests.m in Sources */,
 				0E6B77491C07AE9B00DBF6E0 /* MKTNumberOfInvocationsCheckerTests.m in Sources */,
 				0EEDEB051C0966BB0078A8F0 /* MKTAtMostNumberOfInvocationsCheckerTests.m in Sources */,
@@ -2663,8 +2675,10 @@
 				74A3BDCF19F76DEA006591C9 /* MKTObjectAndProtocolMockTests.m in Sources */,
 				74A3BDD319F76DEA006591C9 /* BlockMatchingTests.m in Sources */,
 				74A3BDD019F76DEA006591C9 /* MKTProtocolMockTests.m in Sources */,
+				65EEDF241E1D38F400463068 /* ObservableObject.m in Sources */,
 				74A3BDD419F76DF0006591C9 /* MockTestCase.m in Sources */,
 				0EEDEB031C0949AF0078A8F0 /* MKTAtLeastNumberOfInvocationsCheckerTests.m in Sources */,
+				65EEDF231E1D389B00463068 /* DisableMockingTests.m in Sources */,
 				74A3BDDA19F76DF0006591C9 /* VerifyProtocolTests.m in Sources */,
 				0E6B774A1C07AE9B00DBF6E0 /* MKTNumberOfInvocationsCheckerTests.m in Sources */,
 				0EEDEB061C0966BB0078A8F0 /* MKTAtMostNumberOfInvocationsCheckerTests.m in Sources */,

--- a/Source/OCMockito/Core/OCMockito.h
+++ b/Source/OCMockito/Core/OCMockito.h
@@ -358,6 +358,28 @@ static inline id <MKTVerificationMode> atMost(NSUInteger maxNumberOfInvocations)
 #endif
 
 
+FOUNDATION_EXPORT void MKTDisableMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber);
+#define MKTDisableMocking(mock) MKTDisableMockingWithLocation(mock, self, __FILE__, __LINE__)
+
+#ifndef MKT_DISABLE_SHORT_SYNTAX
+/*!
+ * @abstract Disables mocking, preventing any more invocations from being handled.
+ * @discussion There are cases where calling stopMocking() on a mock can release come code under
+ * test that was being retained. If that code under test's dealloc method then references another
+ * mock that has not yet been stopped, it will create a strong reference to an object that is
+ * in the process of being deallocated, resulting in an over-release at a later date. A solution
+ * to this is to call disableMocking() on all mocks before calling stopMocking(). This allows
+ * a test to call stopMocking on all of its mocks without having to worry about which order to
+ * call them.
+ *
+ * <b>Name Clash</b><br />
+ * In the event of a name clash, <code>#define MKT_DISABLE_SHORT_SYNTAX</code> and use the synonym
+ * MKTDisableMocking instead.
+ */
+#define disableMocking(mock) MKTDisableMocking(mock)
+#endif
+
+
 FOUNDATION_EXPORT void MKTStopMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber);
 #define MKTStopMocking(mock) MKTStopMockingWithLocation(mock, self, __FILE__, __LINE__)
 

--- a/Source/OCMockito/Core/OCMockito.m
+++ b/Source/OCMockito/Core/OCMockito.m
@@ -140,6 +140,13 @@ id <MKTVerificationMode> MKTAtMost(NSUInteger maxNumberOfInvocations)
     return [[MKTAtMostTimes alloc] initWithMaximumCount:maxNumberOfInvocations];
 }
 
+void MKTDisableMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber)
+{
+    if (reportedInvalidMock(mock, testCase, fileName, lineNumber, @"disableMocking()"))
+        return;
+    [mock mkt_disableMocking];
+}
+
 void MKTStopMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber)
 {
     if (reportedInvalidMock(mock, testCase, fileName, lineNumber, @"stopMocking()"))

--- a/Source/OCMockito/Mocking/MKTBaseMockObject.h
+++ b/Source/OCMockito/Mocking/MKTBaseMockObject.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isMockObject:(id)object;
 
 - (instancetype)init;
+- (void)mkt_disableMocking;
 - (void)mkt_stopMocking;
 
 @end

--- a/Source/OCMockito/Mocking/MKTBaseMockObject.m
+++ b/Source/OCMockito/Mocking/MKTBaseMockObject.m
@@ -16,7 +16,7 @@
 @interface MKTBaseMockObject ()
 @property (nonatomic, strong, readonly) MKTMockingProgress *mockingProgress;
 @property (nonatomic, strong) MKTInvocationContainer *invocationContainer;
-@property (nonatomic, assign) BOOL stoppedMocking;
+@property (nonatomic, assign) BOOL disabledMocking;
 @end
 
 @implementation MKTBaseMockObject
@@ -40,16 +40,21 @@
     return self;
 }
 
+- (void)mkt_disableMocking
+{
+    self.disabledMocking = YES;
+}
+
 - (void)mkt_stopMocking
 {
-    self.stoppedMocking = YES;
+    [self mkt_disableMocking];
     self.invocationContainer = nil;
     [self.mockingProgress reset];
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-    if (self.stoppedMocking)
+    if (self.disabledMocking)
         return;
     if ([self handlingVerifyOfInvocation:invocation])
         return;

--- a/Source/Tests/DisableMockingTests.m
+++ b/Source/Tests/DisableMockingTests.m
@@ -59,6 +59,14 @@
 
 - (void)tearDown
 {
+    // Without this disableMocking stage, 1 of the tests will fail, as we'll create a strong ref from
+    // a mock to an object that's being deallocated. The only other option would be for the test to know
+    // the correct order of stopMocking calls, which means that the test would need implementation-
+    // specific knowledge.
+    for (id trackedMock in trackedMocks) {
+        disableMocking(trackedMock);
+    }
+
     while (trackedMocks.count > 0) {
         id trackedMock = trackedMocks.firstObject;
         stopMocking(trackedMock);

--- a/Source/Tests/DisableMockingTests.m
+++ b/Source/Tests/DisableMockingTests.m
@@ -1,0 +1,99 @@
+//  OCMockito by Jon Reid, http://qualitycoding.org/about/
+//  Copyright 2016 Jonathan M. Reid. See LICENSE.txt
+//  Contribution by Ceri Hughes
+
+#import <XCTest/XCTest.h>
+
+#import "ObservableObject.h"
+#import "OCMockito.h"
+
+@interface DisableMockingTestsHelper : NSObject <ObjectObserver>
+
+@property (nonatomic, strong, readonly) ObservableObject *observableObject1;
+@property (nonatomic, strong, readonly) ObservableObject *observableObject2;
+
+@end
+
+@implementation DisableMockingTestsHelper
+
+- (instancetype)initWithObservableObject1:(ObservableObject *)observableObject1
+                        observableObject2:(ObservableObject *)observableObject2
+{
+    self = [super init];
+    if (self) {
+        _observableObject1 = observableObject1;
+        _observableObject2 = observableObject2;
+        [_observableObject1 addObserver:self];
+    }
+    return self;
+}
+
+- (void)doSomethingLater
+{
+    [self.observableObject2 addObserver:self];
+}
+
+- (void)dealloc
+{
+    [_observableObject1 removeObserver:self];
+    [_observableObject2 removeObserver:self];
+}
+
+@end
+
+
+@interface DisableMockingTests : XCTestCase
+@end
+
+@implementation DisableMockingTests
+{
+    NSMutableArray *trackedMocks;
+}
+
+- (void)setUp
+{
+    [super setUp];
+
+    trackedMocks = [NSMutableArray array];
+}
+
+- (void)tearDown
+{
+    while (trackedMocks.count > 0) {
+        id trackedMock = trackedMocks.firstObject;
+        stopMocking(trackedMock);
+        [trackedMocks removeObjectAtIndex:0];
+    }
+
+    trackedMocks = nil;
+
+    [super tearDown];
+}
+
+- (void)testStoppingObject1ThenObject2
+{
+    ObservableObject *mockObservableObject1 = mock([ObservableObject class]);
+    ObservableObject *mockObservableObject2 = mock([ObservableObject class]);
+
+    [trackedMocks addObject:mockObservableObject1];
+    [trackedMocks addObject:mockObservableObject2];
+
+    DisableMockingTestsHelper *helper = [[DisableMockingTestsHelper alloc] initWithObservableObject1:mockObservableObject1
+                                                                                   observableObject2:mockObservableObject2];
+    (void)helper;
+}
+
+- (void)testStoppingObject2ThenObject1
+{
+    ObservableObject *mockObservableObject1 = mock([ObservableObject class]);
+    ObservableObject *mockObservableObject2 = mock([ObservableObject class]);
+
+    [trackedMocks addObject:mockObservableObject2];
+    [trackedMocks addObject:mockObservableObject1];
+
+    DisableMockingTestsHelper *helper = [[DisableMockingTestsHelper alloc] initWithObservableObject1:mockObservableObject1
+                                                                                   observableObject2:mockObservableObject2];
+    (void)helper;
+}
+
+@end

--- a/Source/Tests/DisableMockingTests.m
+++ b/Source/Tests/DisableMockingTests.m
@@ -4,8 +4,11 @@
 
 #import <XCTest/XCTest.h>
 
+#import "MockTestCase.h"
 #import "ObservableObject.h"
 #import "OCMockito.h"
+
+#import <OCHamcrest/OCHamcrest.h>
 
 @interface DisableMockingTestsHelper : NSObject <ObjectObserver>
 
@@ -102,6 +105,51 @@
     DisableMockingTestsHelper *helper = [[DisableMockingTestsHelper alloc] initWithObservableObject1:mockObservableObject1
                                                                                    observableObject2:mockObservableObject2];
     (void)helper;
+}
+
+@end
+
+@interface DisableMockingProgrammerErrorTests : XCTestCase
+@end
+
+@implementation DisableMockingProgrammerErrorTests
+{
+    MockTestCase *mockTestCase;
+}
+
+- (void)setUp
+{
+    [super setUp];
+
+    mockTestCase = [[MockTestCase alloc] init];
+}
+
+- (void)tearDown
+{
+    mockTestCase = nil;
+
+    [super tearDown];
+}
+
+- (void)testDisableMocking_WithNil_ShouldGiveError
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    disableMockingWithMockTestCase(nil, mockTestCase);
+#pragma clang diagnostic pop
+
+    assertThat(mockTestCase.failureDescription,
+               is(@"Argument passed to disableMocking() should be a mock, but was nil"));
+}
+
+- (void)testDisableMocking_WithNonMock_ShouldGiveError
+{
+    NSMutableArray *realArray = [NSMutableArray array];
+
+    disableMockingWithMockTestCase(realArray, mockTestCase);
+
+    assertThat(mockTestCase.failureDescription,
+               startsWith(@"Argument passed to disableMocking() should be a mock, but was type "));
 }
 
 @end

--- a/Source/Tests/DisableMockingTests.m
+++ b/Source/Tests/DisableMockingTests.m
@@ -1,5 +1,5 @@
 //  OCMockito by Jon Reid, http://qualitycoding.org/about/
-//  Copyright 2016 Jonathan M. Reid. See LICENSE.txt
+//  Copyright 2017 Jonathan M. Reid. See LICENSE.txt
 //  Contribution by Ceri Hughes
 
 #import <XCTest/XCTest.h>

--- a/Source/Tests/DisableMockingTests.m
+++ b/Source/Tests/DisableMockingTests.m
@@ -81,7 +81,7 @@
     [super tearDown];
 }
 
-- (void)testStoppingObject1ThenObject2
+- (void)testStoppingMocks_Object1ThenObject2_ShouldNotCrash
 {
     ObservableObject *mockObservableObject1 = mock([ObservableObject class]);
     ObservableObject *mockObservableObject2 = mock([ObservableObject class]);
@@ -94,7 +94,7 @@
     (void)helper;
 }
 
-- (void)testStoppingObject2ThenObject1
+- (void)testStoppingMocks_Object2ThenObject1_ShouldNotCrash
 {
     ObservableObject *mockObservableObject1 = mock([ObservableObject class]);
     ObservableObject *mockObservableObject2 = mock([ObservableObject class]);

--- a/Source/Tests/MockTestCase.h
+++ b/Source/Tests/MockTestCase.h
@@ -16,6 +16,9 @@
 #define stopMockingWithMockTestCase(mock, mockTestCase)  \
     MKTStopMockingWithLocation(mock, mockTestCase, __FILE__, __LINE__)
 
+#define disableMockingWithMockTestCase(mock, mockTestCase)  \
+    MKTDisableMockingWithLocation(mock, mockTestCase, __FILE__, __LINE__)
+
 
 @interface MockTestCase : NSObject
 

--- a/Source/Tests/ObservableObject.h
+++ b/Source/Tests/ObservableObject.h
@@ -1,5 +1,5 @@
 //  OCMockito by Jon Reid, http://qualitycoding.org/about/
-//  Copyright 2016 Jonathan M. Reid. See LICENSE.txt
+//  Copyright 2017 Jonathan M. Reid. See LICENSE.txt
 //  Contribution by Ceri Hughes
 
 #import <Foundation/Foundation.h>

--- a/Source/Tests/ObservableObject.h
+++ b/Source/Tests/ObservableObject.h
@@ -1,0 +1,13 @@
+//  OCMockito by Jon Reid, http://qualitycoding.org/about/
+//  Copyright 2016 Jonathan M. Reid. See LICENSE.txt
+//  Contribution by Ceri Hughes
+
+#import <Foundation/Foundation.h>
+
+@protocol ObjectObserver <NSObject>
+@end
+
+@interface ObservableObject : NSObject
+- (void)addObserver:(id <ObjectObserver>)observer;
+- (void)removeObserver:(id <ObjectObserver>)observer;
+@end

--- a/Source/Tests/ObservableObject.m
+++ b/Source/Tests/ObservableObject.m
@@ -1,5 +1,5 @@
 //  OCMockito by Jon Reid, http://qualitycoding.org/about/
-//  Copyright 2016 Jonathan M. Reid. See LICENSE.txt
+//  Copyright 2017 Jonathan M. Reid. See LICENSE.txt
 //  Contribution by Ceri Hughes
 
 #import "ObservableObject.h"

--- a/Source/Tests/ObservableObject.m
+++ b/Source/Tests/ObservableObject.m
@@ -1,0 +1,12 @@
+//  OCMockito by Jon Reid, http://qualitycoding.org/about/
+//  Copyright 2016 Jonathan M. Reid. See LICENSE.txt
+//  Contribution by Ceri Hughes
+
+#import "ObservableObject.h"
+
+@implementation ObservableObject
+
+- (void)addObserver:(id <ObjectObserver>)observer {}
+- (void)removeObserver:(id <ObjectObserver>)observer {}
+
+@end

--- a/Source/Tests/StopMockingTests.m
+++ b/Source/Tests/StopMockingTests.m
@@ -4,24 +4,10 @@
 #import "OCMockito.h"
 
 #import "MockTestCase.h"
+#import "ObservableObject.h"
 #import <OCHamcrest/OCHamcrest.h>
 #import <XCTest/XCTest.h>
 
-
-@protocol ObjectObserver <NSObject>
-@end
-
-@interface ObservableObject : NSObject
-- (void)addObserver:(id <ObjectObserver>)observer;
-- (void)removeObserver:(id <ObjectObserver>)observer;
-@end
-
-@implementation ObservableObject
-- (void)addObserver:(id <ObjectObserver>)observer {}
-- (void)removeObserver:(id <ObjectObserver>)observer {}
-@end
-
-@class ObservableObject;
 
 @interface ObservingObject : NSObject <ObjectObserver>
 @property (nonatomic, strong, readonly) ObservableObject *observableObject;


### PR DESCRIPTION
A PR to address the crash that happens when a mock is called from a `dealloc` method (and ONLY the `dealloc` method).

See https://github.com/jonreid/OCMockito/issues/141 for context.