### PR TITLE
Get rid of hack that relies on alphabetical running of test methods

### DIFF
--- a/Source/Tests/StubSingletonTests.m
+++ b/Source/Tests/StubSingletonTests.m
@@ -36,8 +36,19 @@
     assertThat([NSUserDefaults standardUserDefaults], is(@"STUBBED"));
 }
 
-- (void)testStubbedSingleton_ShouldReturnGivenObject_SO_NAMED_TO_EXECUTE_AFTER_TEST_ABOVE_EnsureThatMockDeallocationRestoresOriginalSingleton
+- (void)testStubbedSingleton_EnsureThatMockDeallocationRestoresOriginalSingleton
 {
+    __strong Class anotherMockUserDefaultsClass;
+
+    @autoreleasepool {
+        anotherMockUserDefaultsClass = mockClass([NSUserDefaults class]);
+        stubSingleton(anotherMockUserDefaultsClass, standardUserDefaults);
+        [given([anotherMockUserDefaultsClass standardUserDefaults]) willReturn:@"STUBBED"];
+
+        assertThat([NSUserDefaults standardUserDefaults], is(@"STUBBED"));
+        anotherMockUserDefaultsClass = nil;
+    }
+
     assertThat([NSUserDefaults standardUserDefaults], is(instanceOf([NSUserDefaults class])));
 }
 

--- a/Source/Tests/StubSingletonTests.m
+++ b/Source/Tests/StubSingletonTests.m
@@ -38,15 +38,13 @@
 
 - (void)testStubbedSingleton_EnsureThatMockDeallocationRestoresOriginalSingleton
 {
-    __strong Class anotherMockUserDefaultsClass;
-
     @autoreleasepool {
-        anotherMockUserDefaultsClass = mockClass([NSUserDefaults class]);
-        stubSingleton(anotherMockUserDefaultsClass, standardUserDefaults);
-        [given([anotherMockUserDefaultsClass standardUserDefaults]) willReturn:@"STUBBED"];
+        mockUserDefaultsClass = mockClass([NSUserDefaults class]);
+        stubSingleton(mockUserDefaultsClass, standardUserDefaults);
+        [given([mockUserDefaultsClass standardUserDefaults]) willReturn:@"STUBBED"];
 
         assertThat([NSUserDefaults standardUserDefaults], is(@"STUBBED"));
-        anotherMockUserDefaultsClass = nil;
+        mockUserDefaultsClass = nil;
     }
 
     assertThat([NSUserDefaults standardUserDefaults], is(instanceOf([NSUserDefaults class])));


### PR DESCRIPTION
There was a test that was so-named so this it could rely on the state of a previous test that had run (it relied on the fact that tests are run in alphabetical order). One of the problems with this is that if this test order changes, we'll have no way of knowing as the test would pass regardless.

I've updated the test to add some logic to set up the state as expected, force deallocation using an `autoreleasepool`, then assert that the behaviour is back to normal after deallocation.

@jonreid : Was this the intended behaviour of the test?