### PR TITLE
Convert disableMocking and stopMocking to stopAllMocks

### DIFF
--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -646,6 +646,18 @@
 		638F68D8150FC21A0081DEE6 /* MKTClassObjectMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 638F68D5150FC21A0081DEE6 /* MKTClassObjectMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		638F68D9150FC21A0081DEE6 /* MKTClassObjectMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */; };
 		638F68DA150FC21A0081DEE6 /* MKTClassObjectMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */; };
+		65430DA31E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */; };
+		65430DA41E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */; };
+		65430DA51E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */; };
+		65430DA61E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */; };
+		65430DA71E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */; };
+		65430DA81E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */; };
+		65430DA91E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */; };
+		65430DAA1E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */; };
+		65430DAB1E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */; };
+		65430DAC1E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */; };
+		65D644841E24FD7B00D510B8 /* StopAllMocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65D644831E24FD7B00D510B8 /* StopAllMocksTests.m */; };
+		65D644851E24FD7B00D510B8 /* StopAllMocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65D644831E24FD7B00D510B8 /* StopAllMocksTests.m */; };
 		65EEDE271E1D327600463068 /* DisableMockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE261E1D327600463068 /* DisableMockingTests.m */; };
 		65EEDE2A1E1D337400463068 /* ObservableObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE291E1D337400463068 /* ObservableObject.m */; };
 		65EEDF231E1D389B00463068 /* DisableMockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EEDE261E1D327600463068 /* DisableMockingTests.m */; };
@@ -1020,6 +1032,9 @@
 		638F68D5150FC21A0081DEE6 /* MKTClassObjectMock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTClassObjectMock.h; sourceTree = "<group>"; };
 		638F68D6150FC21A0081DEE6 /* MKTClassObjectMock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTClassObjectMock.m; sourceTree = "<group>"; };
 		638F68DC150FC3210081DEE6 /* MKTClassObjectMockTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTClassObjectMockTests.m; sourceTree = "<group>"; };
+		65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTMockitoTracker.h; sourceTree = "<group>"; };
+		65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTMockitoTracker.m; sourceTree = "<group>"; };
+		65D644831E24FD7B00D510B8 /* StopAllMocksTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StopAllMocksTests.m; sourceTree = "<group>"; };
 		65EEDE261E1D327600463068 /* DisableMockingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DisableMockingTests.m; sourceTree = "<group>"; };
 		65EEDE281E1D337400463068 /* ObservableObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObservableObject.h; sourceTree = "<group>"; };
 		65EEDE291E1D337400463068 /* ObservableObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObservableObject.m; sourceTree = "<group>"; };
@@ -1396,6 +1411,8 @@
 			children = (
 				0827E83313526E7300C39A57 /* OCMockito.h */,
 				0827E83413526E7300C39A57 /* OCMockito.m */,
+				65430DA11E23DEF700632ED8 /* MKTMockitoTracker.h */,
+				65430DA21E23DEF700632ED8 /* MKTMockitoTracker.m */,
 				0827E8401352B6FC00C39A57 /* MKTMockitoCore.h */,
 				0827E8411352B6FC00C39A57 /* MKTMockitoCore.m */,
 				0827E8641352C50400C39A57 /* MKTTestLocation.h */,
@@ -1452,6 +1469,7 @@
 				085A8BC6150718E30018EC66 /* MKTProtocolMockTests.m */,
 				609E9F142955F412A8AFE0AD /* StopMockingTests.m */,
 				65EEDE261E1D327600463068 /* DisableMockingTests.m */,
+				65D644831E24FD7B00D510B8 /* StopAllMocksTests.m */,
 			);
 			name = Mocking;
 			sourceTree = "<group>";
@@ -1638,6 +1656,7 @@
 				7400186D1A58E60200E9AC92 /* MKTThrowsException.h in Headers */,
 				31DDC07A679FF558FB2E3069 /* MKT_TPDWeakProxy.h in Headers */,
 				31DDC37FB11D5CF77669F21B /* MKTDynamicProperties.h in Headers */,
+				65430DA41E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */,
 				609E9E1BB226D286566616E5 /* MKTInvocation.h in Headers */,
 				609E93F0AF4CF88EA58BE4F3 /* MKTParseCallStack.h in Headers */,
 				609E9BEB2716127F240545BB /* MKTCallStackElement.h in Headers */,
@@ -1672,6 +1691,7 @@
 				08E1E74F13633BC10066B0C7 /* MKTNonObjectArgumentMatching.h in Headers */,
 				085A8BCB15071F7B0018EC66 /* MKTProtocolMock.h in Headers */,
 				08FD4B2A1509BEA90004E1FA /* MKTBaseMockObject.h in Headers */,
+				65430DA31E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */,
 				638F68D7150FC21A0081DEE6 /* MKTClassObjectMock.h in Headers */,
 				08E9DC231516738200BD7FB4 /* MKTObjectAndProtocolMock.h in Headers */,
 				361533C6153F275800BB982B /* MKTAtLeastTimes.h in Headers */,
@@ -1806,6 +1826,7 @@
 				247B9FDE1C335EE500B10720 /* MKTClassArgumentGetter.h in Headers */,
 				247B9FE61C335EE500B10720 /* MKTLongArgumentGetter.h in Headers */,
 				247BA0F51C335F3000B10720 /* MKTInvocationsChecker.h in Headers */,
+				65430DA51E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */,
 				247BA0D21C335F2200B10720 /* MKTExecutesBlock.h in Headers */,
 				247B9FE41C335EE500B10720 /* MKTIntArgumentGetter.h in Headers */,
 				247BA00C1C335EF900B10720 /* MKTLongReturnSetter.h in Headers */,
@@ -1890,6 +1911,7 @@
 				247B9FB61C335EE400B10720 /* MKTClassArgumentGetter.h in Headers */,
 				247B9FBE1C335EE400B10720 /* MKTLongArgumentGetter.h in Headers */,
 				247BA1081C335F3100B10720 /* MKTInvocationsChecker.h in Headers */,
+				65430DA61E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */,
 				247BA0C51C335F2100B10720 /* MKTExecutesBlock.h in Headers */,
 				247B9FBC1C335EE400B10720 /* MKTIntArgumentGetter.h in Headers */,
 				247BA0301C335EFA00B10720 /* MKTLongReturnSetter.h in Headers */,
@@ -1974,6 +1996,7 @@
 				247B9F8E1C335EE300B10720 /* MKTClassArgumentGetter.h in Headers */,
 				247B9F961C335EE300B10720 /* MKTLongArgumentGetter.h in Headers */,
 				247BA11B1C335F3200B10720 /* MKTInvocationsChecker.h in Headers */,
+				65430DA71E23DEF700632ED8 /* MKTMockitoTracker.h in Headers */,
 				247BA0DF1C335F2300B10720 /* MKTExecutesBlock.h in Headers */,
 				247B9F941C335EE300B10720 /* MKTIntArgumentGetter.h in Headers */,
 				247BA0541C335EFA00B10720 /* MKTLongReturnSetter.h in Headers */,
@@ -2286,6 +2309,7 @@
 				609E9C9787F014378F462B06 /* MKTCallStackElement.m in Sources */,
 				609E953433A4DE2339277FF0 /* MKTMatchingInvocationsFinder.m in Sources */,
 				609E912EEBD7E28E5C4FD96E /* MKTFilterCallStack.m in Sources */,
+				65430DA91E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */,
 				609E9AE638C6F118F9EA9AD2 /* MKTNumberOfInvocationsChecker.m in Sources */,
 				609E9A78C82C1232480816CE /* MKTAtLeastNumberOfInvocationsChecker.m in Sources */,
 				609E95B526E486C1C76464B7 /* MKTInvocationsChecker.m in Sources */,
@@ -2367,6 +2391,7 @@
 				609E9D91D52DC57C88272B1D /* MKTCallStackElement.m in Sources */,
 				609E9511A39D8AB4D3A34736 /* MKTMatchingInvocationsFinder.m in Sources */,
 				609E9FC124ED879F4E6504AD /* MKTFilterCallStack.m in Sources */,
+				65430DA81E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */,
 				609E9F0872526D05C1724B54 /* MKTNumberOfInvocationsChecker.m in Sources */,
 				609E905D807B1A487CFACCBD /* MKTAtLeastNumberOfInvocationsChecker.m in Sources */,
 				609E934EF0A011ACD93A1ABB /* MKTInvocationsChecker.m in Sources */,
@@ -2448,6 +2473,7 @@
 				247BA0A31C335F1700B10720 /* MKTClassObjectMock.m in Sources */,
 				247B9FF91C335EE500B10720 /* MKTUnsignedLongArgumentGetter.m in Sources */,
 				247B9FD91C335EE500B10720 /* MKTArgumentGetterChain.m in Sources */,
+				65430DAA1E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */,
 				247BA0A11C335F1700B10720 /* MKTBaseMockObject.m in Sources */,
 				247B9FF71C335EE500B10720 /* MKTUnsignedIntArgumentGetter.m in Sources */,
 				247B9FFB1C335EE500B10720 /* MKTUnsignedLongLongArgumentGetter.m in Sources */,
@@ -2529,6 +2555,7 @@
 				247BA0AF1C335F1800B10720 /* MKTClassObjectMock.m in Sources */,
 				247B9FD11C335EE400B10720 /* MKTUnsignedLongArgumentGetter.m in Sources */,
 				247B9FB11C335EE400B10720 /* MKTArgumentGetterChain.m in Sources */,
+				65430DAB1E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */,
 				247BA0AD1C335F1800B10720 /* MKTBaseMockObject.m in Sources */,
 				247B9FCF1C335EE400B10720 /* MKTUnsignedIntArgumentGetter.m in Sources */,
 				247B9FD31C335EE400B10720 /* MKTUnsignedLongLongArgumentGetter.m in Sources */,
@@ -2610,6 +2637,7 @@
 				247BA0BB1C335F1800B10720 /* MKTClassObjectMock.m in Sources */,
 				247B9FA91C335EE300B10720 /* MKTUnsignedLongArgumentGetter.m in Sources */,
 				247B9F891C335EE300B10720 /* MKTArgumentGetterChain.m in Sources */,
+				65430DAC1E23DEF700632ED8 /* MKTMockitoTracker.m in Sources */,
 				247BA0B91C335F1800B10720 /* MKTBaseMockObject.m in Sources */,
 				247B9FA71C335EE300B10720 /* MKTUnsignedIntArgumentGetter.m in Sources */,
 				247B9FAB1C335EE300B10720 /* MKTUnsignedLongLongArgumentGetter.m in Sources */,
@@ -2655,6 +2683,7 @@
 				74A3BDAE19F767B8006591C9 /* VerifyCountAtLeastTimesTests.m in Sources */,
 				74A3BD9B19F767AD006591C9 /* MKTClassObjectMockTests.m in Sources */,
 				74A3BDA319F767B8006591C9 /* NSInvocation+OCMockitoTests.m in Sources */,
+				65D644841E24FD7B00D510B8 /* StopAllMocksTests.m in Sources */,
 				74A3BD9C19F767AD006591C9 /* MKTObjectMockTests.m in Sources */,
 				481D6E991D7CE05100F2C988 /* StubSingletonProgrammerErrorTests.m in Sources */,
 				74A3BDA419F767B8006591C9 /* StubClassTests.m in Sources */,
@@ -2701,6 +2730,7 @@
 				74A3BDE019F76DF0006591C9 /* VerifyCountAtLeastTimesTests.m in Sources */,
 				74A3BDCD19F76DEA006591C9 /* MKTClassObjectMockTests.m in Sources */,
 				74A3BDD519F76DF0006591C9 /* NSInvocation+OCMockitoTests.m in Sources */,
+				65D644851E24FD7B00D510B8 /* StopAllMocksTests.m in Sources */,
 				74A3BDCE19F76DEA006591C9 /* MKTObjectMockTests.m in Sources */,
 				481D6E9A1D7CE05100F2C988 /* StubSingletonProgrammerErrorTests.m in Sources */,
 				74A3BDD619F76DF0006591C9 /* StubClassTests.m in Sources */,

--- a/Source/OCMockito/Core/MKTMockitoTracker.h
+++ b/Source/OCMockito/Core/MKTMockitoTracker.h
@@ -1,0 +1,18 @@
+//  OCMockito by Jon Reid, http://qualitycoding.org/about/
+//  Copyright 2017 Jonathan M. Reid. See LICENSE.txt
+
+#import <Foundation/Foundation.h>
+
+@interface MKTMockitoTracker : NSObject
+
++ (instancetype)sharedTracker;
+
+- (id)createAndTrackMockObject:(Class)classToMock;
+- (id)createAndTrackMockClass:(Class)classToMock;
+- (id)createAndTrackMockProtocol:(Protocol *)protocolToMock;
+- (id)createAndTrackMockProtocolWithoutOptionals:(Protocol *)protocolToMock;
+- (id)createAndTrackMockObject:(Class)classToMock andProtocol:(Protocol *)protocolToMock;
+
+- (void)stopTrackedMocks;
+
+@end

--- a/Source/OCMockito/Core/MKTMockitoTracker.m
+++ b/Source/OCMockito/Core/MKTMockitoTracker.m
@@ -30,35 +30,35 @@
 - (id)createAndTrackMockObject:(Class)classToMock
 {
     id theMock = [[MKTObjectMock alloc] initWithClass:classToMock];
-    [self.trackedMocks addObject:theMock];
+    [self addMock:theMock];
     return theMock;
 }
 
 - (id)createAndTrackMockClass:(Class)classToMock
 {
     id theMock = [[MKTClassObjectMock alloc] initWithClass:classToMock];
-    [self.trackedMocks addObject:theMock];
+    [self addMock:theMock];
     return theMock;
 }
 
 - (id)createAndTrackMockProtocol:(Protocol *)protocolToMock
 {
     id theMock = [[MKTProtocolMock alloc] initWithProtocol:protocolToMock includeOptionalMethods:YES];
-    [self.trackedMocks addObject:theMock];
+    [self addMock:theMock];
     return theMock;
 }
 
 - (id)createAndTrackMockProtocolWithoutOptionals:(Protocol *)protocolToMock
 {
     id theMock = [[MKTProtocolMock alloc] initWithProtocol:protocolToMock includeOptionalMethods:NO];
-    [self.trackedMocks addObject:theMock];
+    [self addMock:theMock];
     return theMock;
 }
 
 - (id)createAndTrackMockObject:(Class)classToMock andProtocol:(Protocol *)protocolToMock
 {
     id theMock = [[MKTObjectAndProtocolMock alloc] initWithClass:classToMock protocol:protocolToMock];
-    [self.trackedMocks addObject:theMock];
+    [self addMock:theMock];
     return theMock;
 }
 

--- a/Source/OCMockito/Core/MKTMockitoTracker.m
+++ b/Source/OCMockito/Core/MKTMockitoTracker.m
@@ -1,0 +1,89 @@
+//  OCMockito by Jon Reid, http://qualitycoding.org/about/
+//  Copyright 2017 Jonathan M. Reid. See LICENSE.txt
+
+#import "MKTMockitoTracker.h"
+
+#import "OCMockito.h"
+
+@interface MKTMockitoTracker ()
+@property (nonatomic, strong, readonly) NSMutableArray<MKTBaseMockObject *> *trackedMocks;
+@end
+
+@implementation MKTMockitoTracker
+
++ (instancetype)sharedTracker
+{
+    static id sharedTracker = nil;
+    if (!sharedTracker)
+        sharedTracker = [[self alloc] init];
+    return sharedTracker;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+        _trackedMocks = [NSMutableArray array];
+    return self;
+}
+
+- (id)createAndTrackMockObject:(Class)classToMock
+{
+    id theMock = [[MKTObjectMock alloc] initWithClass:classToMock];
+    [self.trackedMocks addObject:theMock];
+    return theMock;
+}
+
+- (id)createAndTrackMockClass:(Class)classToMock
+{
+    id theMock = [[MKTClassObjectMock alloc] initWithClass:classToMock];
+    [self.trackedMocks addObject:theMock];
+    return theMock;
+}
+
+- (id)createAndTrackMockProtocol:(Protocol *)protocolToMock
+{
+    id theMock = [[MKTProtocolMock alloc] initWithProtocol:protocolToMock includeOptionalMethods:YES];
+    [self.trackedMocks addObject:theMock];
+    return theMock;
+}
+
+- (id)createAndTrackMockProtocolWithoutOptionals:(Protocol *)protocolToMock
+{
+    id theMock = [[MKTProtocolMock alloc] initWithProtocol:protocolToMock includeOptionalMethods:NO];
+    [self.trackedMocks addObject:theMock];
+    return theMock;
+}
+
+- (id)createAndTrackMockObject:(Class)classToMock andProtocol:(Protocol *)protocolToMock
+{
+    id theMock = [[MKTObjectAndProtocolMock alloc] initWithClass:classToMock protocol:protocolToMock];
+    [self.trackedMocks addObject:theMock];
+    return theMock;
+}
+
+- (void)stopTrackedMocks
+{
+    NSArray *trackedMocksCopy = nil;
+    @synchronized (self.trackedMocks) {
+        trackedMocksCopy = [self.trackedMocks copy];
+        [self.trackedMocks removeAllObjects];
+    }
+
+    for (MKTBaseMockObject *mock in trackedMocksCopy) {
+        [mock disableMocking];
+    }
+
+    for (MKTBaseMockObject *mock in trackedMocksCopy) {
+        [mock stopMocking];
+    }
+}
+
+- (void)addMock:(MKTBaseMockObject *)mock
+{
+    @synchronized (self.trackedMocks) {
+        [self.trackedMocks addObject:mock];
+    }
+}
+
+@end

--- a/Source/OCMockito/Core/OCMockito.h
+++ b/Source/OCMockito/Core/OCMockito.h
@@ -358,42 +358,22 @@ static inline id <MKTVerificationMode> atMost(NSUInteger maxNumberOfInvocations)
 #endif
 
 
-FOUNDATION_EXPORT void MKTDisableMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber);
-#define MKTDisableMocking(mock) MKTDisableMockingWithLocation(mock, self, __FILE__, __LINE__)
-
-#ifndef MKT_DISABLE_SHORT_SYNTAX
-/*!
- * @abstract Disables mocking, preventing any more invocations from being handled.
- * @discussion There are cases where calling stopMocking() on a mock can release code under test
- * that was being retained. If that code under test's dealloc method then references another mock
- * that has not yet been stopped, it will create a strong reference to an object that is in the
- * process of being deallocated, resulting in an over-release at a later date. A solution to this is
- * to call disableMocking() on all mocks before calling stopMocking(). This allows a test to call
- * stopMocking on all of its mocks without having to worry about which order to call them.
- *
- * <b>Name Clash</b><br />
- * In the event of a name clash, <code>#define MKT_DISABLE_SHORT_SYNTAX</code> and use the synonym
- * MKTDisableMocking instead.
- */
-#define disableMocking(mock) MKTDisableMocking(mock)
-#endif
-
-
-FOUNDATION_EXPORT void MKTStopMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber);
-#define MKTStopMocking(mock) MKTStopMockingWithLocation(mock, self, __FILE__, __LINE__)
+FOUNDATION_EXPORT void MKTStopAllMocks(void);
 
 #ifndef MKT_DISABLE_SHORT_SYNTAX
 /*!
  * @abstract Stops mocking and releases arguments.
  * @discussion Mock objects normally retain all message arguments. This is not a problem for most
- * tests, but can sometimes cause retain cycles. In such cases, call stopMocking to tell the mock
- * to release its arguments, and to stop accepting messages. See StopMockingTests.m for an example.
+ * tests, but can sometimes cause retain cycles. To get around this, the framework will keep a
+ * reference to all mocks it creates and will only release them when stopAllMocks is called.
+ * At this point, the framework will also release arguments and stop accepting messages for all
+ * mocks created up to this point. See StopMockingTests.m for an example.
  *
  * <b>Name Clash</b><br />
  * In the event of a name clash, <code>#define MKT_DISABLE_SHORT_SYNTAX</code> and use the synonym
- * MKTStopMocking instead.
+ * MKTStopAllMocks instead.
  */
-#define stopMocking(mock) MKTStopMocking(mock)
+#define stopAllMocks() MKTStopAllMocks()
 #endif
 
 NS_ASSUME_NONNULL_END

--- a/Source/OCMockito/Core/OCMockito.m
+++ b/Source/OCMockito/Core/OCMockito.m
@@ -7,6 +7,7 @@
 #import "MKTAtMostTimes.h"
 #import "MKTExactTimes.h"
 #import "MKTMockitoCore.h"
+#import "MKTMockitoTracker.h"
 
 
 static NSString *actualTypeName(id mock)
@@ -53,27 +54,27 @@ static BOOL reportedInvalidClassMethod(MKTClassObjectMock *theMock, SEL aSelecto
 
 id MKTMock(Class classToMock)
 {
-    return [[MKTObjectMock alloc] initWithClass:classToMock];
+    return [[MKTMockitoTracker sharedTracker] createAndTrackMockObject:classToMock];
 }
 
 id MKTMockClass(Class classToMock)
 {
-    return [[MKTClassObjectMock alloc] initWithClass:classToMock];
+    return [[MKTMockitoTracker sharedTracker] createAndTrackMockClass:classToMock];
 }
 
 id MKTMockProtocol(Protocol *protocolToMock)
 {
-    return [[MKTProtocolMock alloc] initWithProtocol:protocolToMock includeOptionalMethods:YES];
+    return [[MKTMockitoTracker sharedTracker] createAndTrackMockProtocol:protocolToMock];
 }
 
 id MKTMockProtocolWithoutOptionals(Protocol *protocolToMock)
 {
-    return [[MKTProtocolMock alloc] initWithProtocol:protocolToMock includeOptionalMethods:NO];
+    return [[MKTMockitoTracker sharedTracker] createAndTrackMockProtocolWithoutOptionals:protocolToMock];
 }
 
 id MKTMockObjectAndProtocol(Class classToMock, Protocol *protocolToMock)
 {
-    return [[MKTObjectAndProtocolMock alloc] initWithClass:classToMock protocol:protocolToMock];
+    return [[MKTMockitoTracker sharedTracker] createAndTrackMockObject:classToMock andProtocol:protocolToMock];
 }
 
 MKTOngoingStubbing *MKTGivenWithLocation(id testCase, const char *fileName, int lineNumber, ...)
@@ -140,16 +141,7 @@ id <MKTVerificationMode> MKTAtMost(NSUInteger maxNumberOfInvocations)
     return [[MKTAtMostTimes alloc] initWithMaximumCount:maxNumberOfInvocations];
 }
 
-void MKTDisableMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber)
+void MKTStopAllMocks()
 {
-    if (reportedInvalidMock(mock, testCase, fileName, lineNumber, @"disableMocking()"))
-        return;
-    [mock disableMocking];
-}
-
-void MKTStopMockingWithLocation(id mock, id testCase, const char *fileName, int lineNumber)
-{
-    if (reportedInvalidMock(mock, testCase, fileName, lineNumber, @"stopMocking()"))
-        return;
-    [mock stopMocking];
+    [[MKTMockitoTracker sharedTracker] stopTrackedMocks];
 }

--- a/Source/Tests/BlockMatchingTests.m
+++ b/Source/Tests/BlockMatchingTests.m
@@ -40,6 +40,7 @@ typedef NSString *(^BlockReturningString)(void);
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockObj = nil;
     [super tearDown];
 }

--- a/Source/Tests/DisableMockingTests.m
+++ b/Source/Tests/DisableMockingTests.m
@@ -59,13 +59,13 @@
     // a mock to an object that's being deallocated. The only other option would be for the test to know
     // the correct order of stopMocking calls, which means that the test would need implementation-
     // specific knowledge.
-    for (id trackedMock in trackedMocks) {
-        disableMocking(trackedMock);
+    for (MKTBaseMockObject *trackedMock in trackedMocks) {
+        [trackedMock disableMocking];
     }
 
     while (trackedMocks.count > 0) {
-        id trackedMock = trackedMocks.firstObject;
-        stopMocking(trackedMock);
+        MKTBaseMockObject *trackedMock = trackedMocks.firstObject;
+        [trackedMock stopMocking];
         [trackedMocks removeObjectAtIndex:0];
     }
 
@@ -96,50 +96,6 @@
     
     [[DisableMockingTestsHelper alloc] initWithObservableObject1:mockObservableObject1
                                                observableObject2:mockObservableObject2];
-}
-
-@end
-
-
-@interface DisableMockingProgrammerErrorTests : XCTestCase
-@end
-
-@implementation DisableMockingProgrammerErrorTests
-{
-    MockTestCase *mockTestCase;
-}
-
-- (void)setUp
-{
-    [super setUp];
-    mockTestCase = [[MockTestCase alloc] init];
-}
-
-- (void)tearDown
-{
-    mockTestCase = nil;
-    [super tearDown];
-}
-
-- (void)testDisableMocking_WithNil_ShouldGiveError
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    disableMockingWithMockTestCase(nil, mockTestCase);
-#pragma clang diagnostic pop
-
-    assertThat(mockTestCase.failureDescription,
-               is(@"Argument passed to disableMocking() should be a mock, but was nil"));
-}
-
-- (void)testDisableMocking_WithNonMock_ShouldGiveError
-{
-    NSMutableArray *realArray = [NSMutableArray array];
-
-    disableMockingWithMockTestCase(realArray, mockTestCase);
-
-    assertThat(mockTestCase.failureDescription,
-               startsWith(@"Argument passed to disableMocking() should be a mock, but was type "));
 }
 
 @end

--- a/Source/Tests/MKTClassObjectMockTests.m
+++ b/Source/Tests/MKTClassObjectMockTests.m
@@ -24,6 +24,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockStringClass = Nil;
     [super tearDown];
 }

--- a/Source/Tests/MKTObjectAndProtocolMockTests.m
+++ b/Source/Tests/MKTObjectAndProtocolMockTests.m
@@ -57,6 +57,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mock = nil;
     [super tearDown];
 }

--- a/Source/Tests/MKTObjectMockTests.m
+++ b/Source/Tests/MKTObjectMockTests.m
@@ -23,6 +23,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockString = nil;
     [super tearDown];
 }
@@ -133,6 +134,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockDynamicPropertyHolder = nil;
     [super tearDown];
 }

--- a/Source/Tests/MKTProtocolMockTests.m
+++ b/Source/Tests/MKTProtocolMockTests.m
@@ -65,6 +65,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockImplementer = nil;
     [super tearDown];
 }

--- a/Source/Tests/MockTestCase.h
+++ b/Source/Tests/MockTestCase.h
@@ -13,12 +13,6 @@
 #define verifyCountWithMockTestCase(mock, mode, mockTestCase)  \
     MKTVerifyCountWithLocation(mock, mode, mockTestCase, __FILE__, __LINE__)
 
-#define stopMockingWithMockTestCase(mock, mockTestCase)  \
-    MKTStopMockingWithLocation(mock, mockTestCase, __FILE__, __LINE__)
-
-#define disableMockingWithMockTestCase(mock, mockTestCase)  \
-    MKTDisableMockingWithLocation(mock, mockTestCase, __FILE__, __LINE__)
-
 
 @interface MockTestCase : NSObject
 

--- a/Source/Tests/StopAllMocksTests.m
+++ b/Source/Tests/StopAllMocksTests.m
@@ -1,0 +1,186 @@
+//  OCMockito by Jon Reid, http://qualitycoding.org/about/
+//  Copyright 2017 Jonathan M. Reid. See LICENSE.txt
+
+#import <XCTest/XCTest.h>
+
+#import "MockTestCase.h"
+#import "ObservableObject.h"
+#import "OCMockito.h"
+
+#import <OCHamcrest/OCHamcrest.h>
+
+
+@protocol StopAllMocksTestsProtocol <NSObject>
+
+@required
+
+- (NSInteger)requiredMethodWithParameter:(NSInteger)parameter;
+
+@optional
+
+- (NSString *)optionalMethodWithParameter:(NSString *)parameter;
+
+@end
+
+
+@interface StopAllMocksTests : XCTestCase
+@end
+
+@implementation StopAllMocksTests
+
+- (void)tearDown
+{
+    stopAllMocks();
+    [super tearDown];
+}
+
+- (void)testObjectMockExpectationsAreIgnored_AfterStoppingAllMocks
+{
+    NSString *mockObject = mock([NSString class]);
+
+    [given([mockObject stringByAppendingString:@"FOO"]) willReturn:@"BAR"];
+    stopAllMocks();
+
+    [given([mockObject stringByAppendingString:@"FOO"]) willReturn:@"FOOBAR"];
+    assertThat([mockObject stringByAppendingString:@"FOO"], is(nilValue()));
+}
+
+- (void)testNewObjectMocks_WorkAsExpected_AfterStoppingAllMocks
+{
+    NSString *mockObject = mock([NSString class]);
+
+    [given([mockObject stringByAppendingString:@"FOO"]) willReturn:@"BAR"];
+    stopAllMocks();
+
+    mockObject = mock([NSString class]);
+    [given([mockObject stringByAppendingString:@"FOO"]) willReturn:@"FOOBAR"];
+    assertThat([mockObject stringByAppendingString:@"FOO"], is(equalTo(@"FOOBAR")));
+}
+
+- (void)testClassMockExpectationsAreIgnored_AfterStoppingAllMocks
+{
+    __strong Class mockObject = mockClass([NSArray class]);
+    NSArray *array1 = @[];
+    NSArray *array2 = @[];
+
+    [given([mockObject array]) willReturn:array1];
+    stopAllMocks();
+
+    [given([mockObject array]) willReturn:array2];
+    assertThat([mockObject array], is(nilValue()));
+}
+
+- (void)testNewClassMocks_WorkAsExpected_AfterStoppingAllMocks
+{
+    __strong Class mockObject = mockClass([NSArray class]);
+    NSArray *array1 = @[];
+    NSArray *array2 = @[];
+
+    [given([mockObject array]) willReturn:array1];
+    stopAllMocks();
+
+    mockObject = mockClass([NSArray class]);
+    [given([mockObject array]) willReturn:array2];
+    assertThat([mockObject array], is(sameInstance(array2)));
+}
+
+- (void)testSingletonMocksAreReverted_AfterStoppingAllMocks
+{
+    __strong Class mockObject = mockClass([NSUserDefaults class]);
+    NSUserDefaults *mockUserDefaults1 = mock([NSUserDefaults class]);
+    NSUserDefaults *mockUserDefaults2 = mock([NSUserDefaults class]);
+    stubSingleton(mockObject, standardUserDefaults);
+
+    [given([mockObject standardUserDefaults]) willReturn:mockUserDefaults1];
+    stopAllMocks();
+
+    [given([mockObject standardUserDefaults]) willReturn:mockUserDefaults2];
+    assertThat([NSUserDefaults standardUserDefaults], is(instanceOf([NSUserDefaults class])));
+}
+
+- (void)testNewSingletonMocks_WorkAsExpected_AfterStoppingAllMocks
+{
+    __strong Class mockObject = mockClass([NSUserDefaults class]);
+    NSUserDefaults *mockUserDefaults1 = mock([NSUserDefaults class]);
+    NSUserDefaults *mockUserDefaults2 = mock([NSUserDefaults class]);
+    stubSingleton(mockObject, standardUserDefaults);
+
+    [given([mockObject standardUserDefaults]) willReturn:mockUserDefaults1];
+    stopAllMocks();
+
+    mockObject = mockClass([NSUserDefaults class]);
+    stubSingleton(mockObject, standardUserDefaults);
+    [given([mockObject standardUserDefaults]) willReturn:mockUserDefaults2];
+    assertThat([NSUserDefaults standardUserDefaults], is(sameInstance(mockUserDefaults2)));
+}
+
+- (void)testProtocolMockExpectationsAreIgnored_AfterStoppingAllMocks
+{
+    id<StopAllMocksTestsProtocol> mockObject = mockProtocol(@protocol(StopAllMocksTestsProtocol));
+
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"BAR"];
+    stopAllMocks();
+
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"FOOBAR"];
+    assertThat([mockObject optionalMethodWithParameter:@"FOO"], is(nilValue()));
+}
+
+- (void)testNewProtocolMocks_WorkAsExpected_AfterStoppingAllMocks
+{
+    id<StopAllMocksTestsProtocol> mockObject = mockProtocol(@protocol(StopAllMocksTestsProtocol));
+
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"BAR"];
+    stopAllMocks();
+
+    mockObject = mockProtocol(@protocol(StopAllMocksTestsProtocol));
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"FOOBAR"];
+    assertThat([mockObject optionalMethodWithParameter:@"FOO"], is(equalTo(@"FOOBAR")));
+}
+
+- (void)testProtocolWithoutOptionalsMockExpectationsAreIgnored_AfterStoppingAllMocks
+{
+    id<StopAllMocksTestsProtocol> mockObject = mockProtocolWithoutOptionals(@protocol(StopAllMocksTestsProtocol));
+
+    [given([mockObject requiredMethodWithParameter:1]) willReturn:@1];
+    stopAllMocks();
+
+    [given([mockObject requiredMethodWithParameter:1]) willReturn:@2];
+    assertThatInteger([mockObject requiredMethodWithParameter:1], is(equalToInteger(0)));
+}
+
+- (void)testNewProtocolWithoutOptionalsMocks_WorkAsExpected_AfterStoppingAllMocks
+{
+    id<StopAllMocksTestsProtocol> mockObject = mockProtocolWithoutOptionals(@protocol(StopAllMocksTestsProtocol));
+
+    [given([mockObject requiredMethodWithParameter:1]) willReturn:@1];
+    stopAllMocks();
+
+    mockObject = mockProtocolWithoutOptionals(@protocol(StopAllMocksTestsProtocol));
+    [given([mockObject requiredMethodWithParameter:1]) willReturn:@2];
+    assertThatInteger([mockObject requiredMethodWithParameter:1], is(equalToInteger(2)));
+}
+
+- (void)testObjectAndProtocolMockExpectationsAreIgnored_AfterStoppingAllMocks
+{
+    NSObject<StopAllMocksTestsProtocol> *mockObject = mockObjectAndProtocol([NSObject class], @protocol(StopAllMocksTestsProtocol));
+
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"BAR"];
+    stopAllMocks();
+
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"FOOBAR"];
+    assertThat([mockObject optionalMethodWithParameter:@"FOO"], is(nilValue()));
+}
+
+- (void)testNewObjectAndProtocolMocks_WorkAsExpected_AfterStoppingAllMocks
+{
+    NSObject<StopAllMocksTestsProtocol> *mockObject = mockObjectAndProtocol([NSObject class], @protocol(StopAllMocksTestsProtocol));
+
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"BAR"];
+    stopAllMocks();
+
+    mockObject = mockObjectAndProtocol([NSObject class], @protocol(StopAllMocksTestsProtocol));
+    [given([mockObject optionalMethodWithParameter:@"FOO"]) willReturn:@"FOOBAR"];
+    assertThat([mockObject optionalMethodWithParameter:@"FOO"], is(equalTo(@"FOOBAR")));
+}
+
+@end

--- a/Source/Tests/StopMockingTests.m
+++ b/Source/Tests/StopMockingTests.m
@@ -56,7 +56,7 @@
 
 - (void)tearDown
 {
-    stopMocking(mockObservableObject);
+    stopAllMocks();
     mockObservableObject = nil;
     observingObject = nil;
     [super tearDown];
@@ -64,49 +64,5 @@
 
 - (void)test1 {}
 - (void)test2 {}
-
-@end
-
-
-@interface StopMockingProgrammerErrorTests : XCTestCase
-@end
-
-@implementation StopMockingProgrammerErrorTests
-{
-    MockTestCase *mockTestCase;
-}
-
-- (void)setUp
-{
-    [super setUp];
-    mockTestCase = [[MockTestCase alloc] init];
-}
-
-- (void)tearDown
-{
-    mockTestCase = nil;
-    [super tearDown];
-}
-
-- (void)testStopMocking_WithNil_ShouldGiveError
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    stopMockingWithMockTestCase(nil, mockTestCase);
-#pragma clang diagnostic pop
-
-    assertThat(mockTestCase.failureDescription,
-            is(@"Argument passed to stopMocking() should be a mock, but was nil"));
-}
-
-- (void)testStopMocking_WithNonMock_ShouldGiveError
-{
-    NSMutableArray *realArray = [NSMutableArray array];
-
-    stopMockingWithMockTestCase(realArray, mockTestCase);
-
-    assertThat(mockTestCase.failureDescription,
-            startsWith(@"Argument passed to stopMocking() should be a mock, but was type "));
-}
 
 @end

--- a/Source/Tests/StubClassTests.m
+++ b/Source/Tests/StubClassTests.m
@@ -31,6 +31,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     myMockClass = Nil;
     [super tearDown];
 }

--- a/Source/Tests/StubObjectTests.m
+++ b/Source/Tests/StubObjectTests.m
@@ -78,6 +78,7 @@ static inline double *createArrayOf10Doubles(void)
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockObject = nil;
     [super tearDown];
 }

--- a/Source/Tests/StubProtocolTests.m
+++ b/Source/Tests/StubProtocolTests.m
@@ -39,6 +39,7 @@ typedef struct {
 
 - (void)tearDown
 {
+    stopAllMocks();
     myMockProtocol = nil;
     [super tearDown];
 }

--- a/Source/Tests/StubSingletonProgrammerErrorTests.m
+++ b/Source/Tests/StubSingletonProgrammerErrorTests.m
@@ -24,6 +24,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockTestCase = nil;
     [super tearDown];
 }

--- a/Source/Tests/StubSingletonTests.m
+++ b/Source/Tests/StubSingletonTests.m
@@ -24,6 +24,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockUserDefaultsClass = Nil;
     [super tearDown];
 }
@@ -44,6 +45,7 @@
         [given([mockUserDefaultsClass standardUserDefaults]) willReturn:@"STUBBED"];
 
         assertThat([NSUserDefaults standardUserDefaults], is(@"STUBBED"));
+        stopAllMocks();
         mockUserDefaultsClass = nil;
     }
 
@@ -55,7 +57,7 @@
     stubSingleton(mockUserDefaultsClass, standardUserDefaults);
     [given([mockUserDefaultsClass standardUserDefaults]) willReturn:@"STUBBED"];
     
-    stopMocking(mockUserDefaultsClass);
+    stopAllMocks();
     
     assertThat([NSUserDefaults standardUserDefaults], is(instanceOf([NSUserDefaults class])));
 }
@@ -81,8 +83,7 @@
     stubSingleton(secondMockClass, standardUserDefaults);
     [given([secondMockClass standardUserDefaults]) willReturn:@"STUBBED2"];
     
-    stopMocking(mockUserDefaultsClass);
-    stopMocking(secondMockClass);
+    stopAllMocks();
     
     assertThat([NSUserDefaults standardUserDefaults], is(instanceOf([NSUserDefaults class])));
 }

--- a/Source/Tests/VerifyClassObjectTests.m
+++ b/Source/Tests/VerifyClassObjectTests.m
@@ -24,6 +24,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockStringClass = Nil;
     [super tearDown];
 }

--- a/Source/Tests/VerifyCountAtLeastTimesTests.m
+++ b/Source/Tests/VerifyCountAtLeastTimesTests.m
@@ -27,6 +27,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockArray = nil;
     mockTestCase = nil;
     [super tearDown];

--- a/Source/Tests/VerifyCountAtMostTimesTests.m
+++ b/Source/Tests/VerifyCountAtMostTimesTests.m
@@ -27,6 +27,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockArray = nil;
     mockTestCase = nil;
     [super tearDown];

--- a/Source/Tests/VerifyCountNeverTests.m
+++ b/Source/Tests/VerifyCountNeverTests.m
@@ -24,6 +24,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockArray = nil;
     [super tearDown];
 }

--- a/Source/Tests/VerifyCountTimesTests.m
+++ b/Source/Tests/VerifyCountTimesTests.m
@@ -26,6 +26,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockArray = nil;
     mockTestCase = nil;
     [super tearDown];

--- a/Source/Tests/VerifyObjectAndProtocolTests.m
+++ b/Source/Tests/VerifyObjectAndProtocolTests.m
@@ -26,6 +26,7 @@
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockLockingArray = nil;
     mockTestCase = nil;
     [super tearDown];

--- a/Source/Tests/VerifyObjectTests.m
+++ b/Source/Tests/VerifyObjectTests.m
@@ -49,6 +49,7 @@ static inline double *createArrayOf10Doubles(void)
 
 - (void)tearDown
 {
+    stopAllMocks();
     mockArray = nil;
     mockTestCase = nil;
     [super tearDown];

--- a/Source/Tests/VerifyProtocolTests.m
+++ b/Source/Tests/VerifyProtocolTests.m
@@ -31,6 +31,7 @@
 - (void)tearDown
 {
     [archiver finishEncoding];
+    stopAllMocks();
     mockLock = nil;
     mockDelegate = nil;
     mockTestCase = nil;


### PR DESCRIPTION
Hi Jon,

Here's what I was thinking around the `stopAllMocks()` functionality I talked about in https://github.com/jonreid/OCMockito/issues/141

The idea is that OCMockito will keep a reference to any mocks objects it creates, and when `stopAllMocks()` is called, it will take care of the intricacies of disabling all mocks, *then* stopping all mocks, thus freeing the test writer from having to understand the different memory management and crash scenarios that can manifest when doing this manually.

As such, I've also removed `disableMocking()` and `stopMocking()` from the public API. Testers now just need to make sure they call `stopAllMocks()` from the `tearDown` method (or equivalent) of their test.

### Changes in behaviour

Before this change, if a test didn't call stopMocking() on a mock, it *may or may not* have leaked, depending on the way the mock was used. Now, if a test doesn't call stopAllMocks(), it *will* leak memory, both from the mocks and all of their message arguments. Likewise, before this change, when setting the mock to nil, deallocation *may or may not* have run. Now, if stopAllMocks() has been called, deallocation is guaranteed to run when the mock is set to nil.

### Other behaviour

Verifying mocks after `stopAllMocks()` has been called is undefined. As I understand it, this will never fail regardless of how the mock was used prior to `stopAllMocks()`. This is no different from the current verify behaviour after `stopMocking()` is called on a mock though.

Let me know what you think. Hopefully, this will lead to a simpler and more understandable API (with respect to memory management at least).

Also, just to be extra clear - this is an API-breaking change.

Thanks!

Cer
