### PR TITLE
Threaded use can cause exception to be thrown while matching

### DIFF
--- a/Source/OCMockito/Stubbing/MKTInvocationContainer.m
+++ b/Source/OCMockito/Stubbing/MKTInvocationContainer.m
@@ -59,7 +59,7 @@
 
 - (MKTStubbedInvocationMatcher *)findAnswerFor:(NSInvocation *)invocation
 {
-    for (MKTStubbedInvocationMatcher *s in self.stubbed)
+    for (MKTStubbedInvocationMatcher *s in [self.stubbed copy])
         if ([s matches:invocation])
             return s;
     return nil;


### PR DESCRIPTION
This fixes an issue where the array storing the matchers could be changed while it was being iterated over, causing an exception to be thrown. It can arises when one thread is trying to add a new matcher while another is executing a mocked method. Probably not a normal use case, but it can happen.