### PR TITLE
Add isKindOfClass to ObjectAndProtocolMock

### DIFF
--- a/Source/OCMockito/Mocking/MKTObjectAndProtocolMock.m
+++ b/Source/OCMockito/Mocking/MKTObjectAndProtocolMock.m
@@ -46,6 +46,11 @@
 
 #pragma mark NSObject protocol
 
+- (BOOL)isKindOfClass:(Class)aClass
+{
+    return [self.mockedClass isSubclassOfClass:aClass];
+}
+
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
     return [self.dynamicProperties methodSignatureForSelector:aSelector] ||

--- a/Source/Tests/MKTObjectAndProtocolMockTests.m
+++ b/Source/Tests/MKTObjectAndProtocolMockTests.m
@@ -117,6 +117,21 @@
     assertThat(signature, equalTo([obj methodSignatureForSelector:sel]));
 }
 
+- (void)testShouldBeKindOfSameClass
+{
+    XCTAssertTrue([mock isKindOfClass:[TestClass class]]);
+}
+
+- (void)testShouldBeKindOfSubclass
+{
+    XCTAssertTrue([mock isKindOfClass:[NSObject class]]);
+}
+
+- (void)testShouldNotBeKindOfDifferentClass
+{
+    XCTAssertFalse([mock isKindOfClass:[NSArray class]]);
+}
+
 - (void)testShouldConformToItsOwnProtocol
 {
     XCTAssertTrue([mock conformsToProtocol:@protocol(TestProtocol)]);


### PR DESCRIPTION
Changes the behavior of `-[MKTObjectAndProtocolMock isKindOfClass:]` to match that of `-[MKTObjectMock isKindOfClass:]`, as it currently always returns `MKTObjectAndProtocolMock`.