### PR TITLE
Add relation from MKTMockingProgress to the object it's mocking MKTBaseMockObject

### DIFF
--- a/Source/OCMockito.xcodeproj/project.pbxproj
+++ b/Source/OCMockito.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		74A3BDAC19F767B8006591C9 /* VerifyCountNeverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DDCACAAA78463D591CB091 /* VerifyCountNeverTests.m */; };
 		74A3BDAD19F767B8006591C9 /* VerifyProgrammerErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DDCF493BD60433EC2CE5B4 /* VerifyProgrammerErrorTests.m */; };
 		74A3BDAE19F767B8006591C9 /* VerifyCountAtLeastTimesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 31DDC4EC077BF6043636A170 /* VerifyCountAtLeastTimesTests.m */; };
+		7B1B7A9726B03DD00029A2AF /* VerifyAndStubTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1B7A9626B03DD00029A2AF /* VerifyAndStubTests.m */; };
 		A723493A2582331E0084C514 /* OCHamcrest.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7234939258233130084C514 /* OCHamcrest.xcframework */; };
 		A72349422582331E0084C514 /* OCHamcrest.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7234939258233130084C514 /* OCHamcrest.xcframework */; };
 		A723495A258233200084C514 /* OCHamcrest.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7234939258233130084C514 /* OCHamcrest.xcframework */; };
@@ -802,6 +803,7 @@
 		748491901A5919EC006A7579 /* MKTExecutesBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTExecutesBlock.h; sourceTree = "<group>"; };
 		748491911A5919EC006A7579 /* MKTExecutesBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTExecutesBlock.m; sourceTree = "<group>"; };
 		74A3BD8219F765E2006591C9 /* OCMockitoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OCMockitoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B1B7A9626B03DD00029A2AF /* VerifyAndStubTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VerifyAndStubTests.m; sourceTree = "<group>"; };
 		A7234939258233130084C514 /* OCHamcrest.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCHamcrest.xcframework; path = "../Frameworks/OCHamcrest-8.0.0/OCHamcrest.xcframework"; sourceTree = "<group>"; };
 		BB17021FCA430FAD53E07A7D /* MKTSingletonSwizzler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MKTSingletonSwizzler.h; sourceTree = "<group>"; };
 		BB17024B02E780AE9F1DF220 /* MKTSingletonSwizzler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MKTSingletonSwizzler.m; sourceTree = "<group>"; };
@@ -1181,6 +1183,7 @@
 				31DDCF493BD60433EC2CE5B4 /* VerifyProgrammerErrorTests.m */,
 				31DDC4EC077BF6043636A170 /* VerifyCountAtLeastTimesTests.m */,
 				2AD030DA1A8E4EA0001B43DC /* VerifyCountAtMostTimesTests.m */,
+				7B1B7A9626B03DD00029A2AF /* VerifyAndStubTests.m */,
 			);
 			name = Verifying;
 			sourceTree = "<group>";
@@ -2149,6 +2152,7 @@
 				0E5F663A1D209EBB00D01554 /* StubbingCopyTests.m in Sources */,
 				74A3BD9D19F767AD006591C9 /* MKTObjectAndProtocolMockTests.m in Sources */,
 				74A3BDA119F767AD006591C9 /* BlockMatchingTests.m in Sources */,
+				7B1B7A9726B03DD00029A2AF /* VerifyAndStubTests.m in Sources */,
 				74A3BD9E19F767AD006591C9 /* MKTProtocolMockTests.m in Sources */,
 				74A3BDA219F767B8006591C9 /* MockTestCase.m in Sources */,
 				0EEDEB021C0949AF0078A8F0 /* MKTAtLeastNumberOfInvocationsCheckerTests.m in Sources */,

--- a/Source/OCMockito/Core/MKTMockingProgress.h
+++ b/Source/OCMockito/Core/MKTMockingProgress.h
@@ -7,6 +7,7 @@
 
 @class MKTInvocationMatcher;
 @class MKTOngoingStubbing;
+@class MKTBaseMockObject;
 @protocol HCMatcher;
 @protocol MKTVerificationMode;
 
@@ -24,8 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reportOngoingStubbing:(MKTOngoingStubbing *)ongoingStubbing;
 - (MKTOngoingStubbing *)pullOngoingStubbing;
 
-- (void)verificationStarted:(id <MKTVerificationMode>)mode atLocation:(MKTTestLocation)location;
-- (id <MKTVerificationMode>)pullVerificationMode;
+- (void)verificationStarted:(id <MKTVerificationMode>)mode atLocation:(MKTTestLocation)location withMock:(MKTBaseMockObject *)mock;
+
+- (id <MKTVerificationMode>)pullVerificationModeWithMock:(MKTBaseMockObject *)mock;
 
 - (void)setMatcher:(id <HCMatcher>)matcher forArgument:(NSUInteger)index;
 - (MKTInvocationMatcher *)pullInvocationMatcher;

--- a/Source/OCMockito/Core/MKTMockingProgress.m
+++ b/Source/OCMockito/Core/MKTMockingProgress.m
@@ -6,12 +6,14 @@
 #import "MKTInvocationMatcher.h"
 #import "MKTOngoingStubbing.h"
 #import "MKTVerificationMode.h"
-
+#import "MKTBaseMockObject.h"
 
 @interface MKTMockingProgress ()
 @property (nonatomic, assign, readwrite) MKTTestLocation testLocation;
 @property (nonatomic, strong) MKTInvocationMatcher *invocationMatcher;
 @property (nonatomic, strong) id <MKTVerificationMode> verificationMode;
+@property (nonatomic, strong) MKTBaseMockObject *verificationModeMockObject;
+
 @property (nonatomic, strong) MKTOngoingStubbing *ongoingStubbing;
 @end
 
@@ -49,16 +51,20 @@
     return result;
 }
 
-- (void)verificationStarted:(id <MKTVerificationMode>)mode atLocation:(MKTTestLocation)location
+- (void)verificationStarted:(id <MKTVerificationMode>)mode atLocation:(MKTTestLocation)location withMock:(MKTBaseMockObject *)mock
 {
     self.verificationMode = mode;
+    self.verificationModeMockObject = mock;
     [self setTestLocation:location];
 }
 
-- (id <MKTVerificationMode>)pullVerificationMode
+- (id <MKTVerificationMode>)pullVerificationModeWithMock:(MKTBaseMockObject *)mock
 {
     id <MKTVerificationMode> result = self.verificationMode;
-    self.verificationMode = nil;
+
+    if ([mock isEqual:self.verificationModeMockObject])
+        self.verificationMode = nil;
+
     return result;
 }
 

--- a/Source/OCMockito/Core/MKTMockitoCore.m
+++ b/Source/OCMockito/Core/MKTMockitoCore.m
@@ -5,7 +5,7 @@
 
 #import "MKTMockingProgress.h"
 #import "MKTVerificationMode.h"
-
+#import "MKTObjectMock.h"
 
 @interface MKTMockitoCore ()
 @property (nonatomic, strong, readonly) MKTMockingProgress *mockingProgress;
@@ -44,7 +44,7 @@
         withMode:(id <MKTVerificationMode>)mode
       atLocation:(MKTTestLocation)location
 {
-    [self.mockingProgress verificationStarted:mode atLocation:location];
+    [self.mockingProgress verificationStarted:mode atLocation:location withMock:mock];
     return mock;
 }
 

--- a/Source/OCMockito/Mocking/MKTBaseMockObject.m
+++ b/Source/OCMockito/Mocking/MKTBaseMockObject.m
@@ -63,7 +63,7 @@
 
 - (BOOL)handlingVerifyOfInvocation:(NSInvocation *)invocation
 {
-    id <MKTVerificationMode> verificationMode = [self.mockingProgress pullVerificationMode];
+    id <MKTVerificationMode> verificationMode = [self.mockingProgress pullVerificationModeWithMock:self];
     if (verificationMode)
         [self verifyInvocation:invocation usingVerificationMode:verificationMode];
     return verificationMode != nil;

--- a/Source/Tests/MKTClassObjectMockTests.m
+++ b/Source/Tests/MKTClassObjectMockTests.m
@@ -35,7 +35,7 @@
 
 - (void)testMock_ShouldAnswerSameMethodSignatureForSelectorAsRealObject
 {
-    SEL sel = @selector(string);
+    SEL sel = @selector(text);
 
     NSMethodSignature *signature = [mockStringClass methodSignatureForSelector:sel];
 

--- a/Source/Tests/MKTMockingProgressTests.m
+++ b/Source/Tests/MKTMockingProgressTests.m
@@ -7,6 +7,7 @@
 #import "MKTInvocationContainer.h"
 #import "MKTInvocationMatcher.h"
 #import "MKTOngoingStubbing.h"
+#import "MKTBaseMockObject.h"
 
 #import <OCHamcrest/OCHamcrest.h>
 @import XCTest;
@@ -18,12 +19,14 @@
 @implementation MKTMockingProgressTests
 {
     MKTMockingProgress *mockingProgress;
+    MKTBaseMockObject *baseMockObject;
 }
 
 - (void)setUp
 {
     [super setUp];
     mockingProgress = [[MKTMockingProgress alloc] init];
+    baseMockObject = [[MKTBaseMockObject alloc] init];
 }
 
 - (void)tearDown
@@ -62,26 +65,30 @@
 
 - (void)testPullVerificationMode_WithoutVerificationStarted_ShouldReturnNil
 {
-    assertThat([mockingProgress pullVerificationMode], is(nilValue()));
+    assertThat([mockingProgress pullVerificationModeWithMock:baseMockObject], is(nilValue()));
 }
 
 - (void)testPullVerificationMode_WithVerificationStarted_ShouldReturnMode
 {
     id <MKTVerificationMode> mode = [[MKTExactTimes alloc] initWithCount:42];
 
-    [mockingProgress verificationStarted:mode atLocation:MKTTestLocationMake(self, __FILE__, __LINE__)];
+    [mockingProgress verificationStarted:mode
+                              atLocation:MKTTestLocationMake(self, __FILE__, __LINE__)
+                                withMock:baseMockObject];
 
-    assertThat([mockingProgress pullVerificationMode], is(sameInstance(mode)));
+    assertThat([mockingProgress pullVerificationModeWithMock:baseMockObject], is(sameInstance(mode)));
 }
 
 - (void)testPullVerificationMode_ShouldClearCurrentVerification
 {
     id <MKTVerificationMode> mode = [[MKTExactTimes alloc] initWithCount:42];
 
-    [mockingProgress verificationStarted:mode atLocation:MKTTestLocationMake(self, __FILE__, __LINE__)];
-    [mockingProgress pullVerificationMode];
+    [mockingProgress verificationStarted:mode
+                              atLocation:MKTTestLocationMake(self, __FILE__, __LINE__)
+                                withMock:baseMockObject];
+    [mockingProgress pullVerificationModeWithMock:baseMockObject];
 
-    assertThat([mockingProgress pullVerificationMode], is(nilValue()));
+    assertThat([mockingProgress pullVerificationModeWithMock:baseMockObject], is(nilValue()));
 }
 
 - (void)testPullInvocationMatcher_WithoutSettingMatchers_ShouldReturnNil

--- a/Source/Tests/VerifyAndStubTests.m
+++ b/Source/Tests/VerifyAndStubTests.m
@@ -1,0 +1,91 @@
+//  OCMockito by Jon Reid, https://qualitycoding.org
+//  Copyright 2021 Quality Coding, Inc. See LICENSE.txt
+
+#import "OCMockito.h"
+
+#import "MockTestCase.h"
+#import <OCHamcrest/OCHamcrest.h>
+@import XCTest;
+
+/*
+ A --(useC:)--> B --(processStringFromC:)--> C
+ */
+
+@interface C: NSObject
+@property (nonatomic, copy) NSString *text;
+@end
+
+@implementation C
+@end
+
+@interface B: NSObject
+- (void)processStringFromC:(NSString *)string;
+@end
+
+@implementation B
+- (void)processStringFromC:(NSString *)string { }
+@end
+
+
+@interface A: NSObject
+
+- (void)useC:(C *)c;
+
+@property (nonatomic, strong, readonly) B *b; // always uninitialized
+
+@end
+
+@implementation A
+
+- (void)useC:(C *)c
+{
+    [self.b processStringFromC:c.text];
+}
+
+@end
+
+@interface VerifyAndStubTests : XCTestCase
+@end
+
+@implementation VerifyAndStubTests
+{
+    MockTestCase *mockTestCase;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    mockTestCase = [[MockTestCase alloc] init];
+}
+
+- (void)testVerify_whileNotStubbing_ShouldFail
+{
+    // Given
+    A *a = [[A alloc] init]; // A is not initialized with B
+    B *b = mock(B.class); // not used at all
+    C *c = [[C alloc] init]; // not stubbing
+
+    // When
+    [a useC:c];
+
+    // Then
+    [verifyWithMockTestCase(b, mockTestCase) processStringFromC:c.text];
+    assertThat(@(mockTestCase.failureCount), is(@1));
+}
+
+- (void)testVerify_whileStubbing_ShouldFail
+{
+    // Given
+    A *a = [[A alloc] init]; // A is not initialized with B
+    B *b = mock(B.class); // not used at all
+    C *c = mock(C.class); // stubbing
+
+    // When
+    [a useC:c];
+
+    // Then
+    [verifyWithMockTestCase(b, mockTestCase) processStringFromC:c.text];
+    assertThat(@(mockTestCase.failureCount), is(@1));
+}
+
+@end


### PR DESCRIPTION
Add relation from MKTMockingProgress to the object it's mocking MKTBaseMockObject  in order to prevent verifying while stubbing false positives

See https://github.com/jonreid/OCMockito/issues/162 for more details