### PR TITLE
Pull verificationMode only when verifying

### DIFF
--- a/Source/OCMockito/Core/MKTMockingProgress.h
+++ b/Source/OCMockito/Core/MKTMockingProgress.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)verificationStarted:(id <MKTVerificationMode>)mode atLocation:(MKTTestLocation)location withMock:(MKTBaseMockObject *)mock;
 
-- (id <MKTVerificationMode>)pullVerificationModeWithMock:(MKTBaseMockObject *)mock;
+- (nullable id <MKTVerificationMode>)pullVerificationModeWithMock:(MKTBaseMockObject *)mock;
 
 - (void)setMatcher:(id <HCMatcher>)matcher forArgument:(NSUInteger)index;
 - (MKTInvocationMatcher *)pullInvocationMatcher;

--- a/Source/OCMockito/Core/MKTMockingProgress.m
+++ b/Source/OCMockito/Core/MKTMockingProgress.m
@@ -58,14 +58,15 @@
     [self setTestLocation:location];
 }
 
-- (id <MKTVerificationMode>)pullVerificationModeWithMock:(MKTBaseMockObject *)mock
+- (nullable id <MKTVerificationMode>)pullVerificationModeWithMock:(MKTBaseMockObject *)mock
 {
-    id <MKTVerificationMode> result = self.verificationMode;
-
-    if ([mock isEqual:self.verificationModeMockObject])
+    if (self.verificationMode != nil && [mock isEqual:self.verificationModeMockObject]) {
+        id <MKTVerificationMode> result = self.verificationMode;
         self.verificationMode = nil;
-
-    return result;
+        return result;
+    } else {
+        return nil;
+    }
 }
 
 - (void)setMatcher:(id <HCMatcher>)matcher forArgument:(NSUInteger)index

--- a/Source/Tests/VerifyAndStubTests.m
+++ b/Source/Tests/VerifyAndStubTests.m
@@ -58,6 +58,21 @@
     mockTestCase = [[MockTestCase alloc] init];
 }
 
+- (void)testStub_whileVerify
+{
+    // Given
+    B *b = mock(B.class);
+    C *c = mock(C.class);
+
+    [given(c.text) willReturn:@"test"];
+
+    // When
+    [b processStringFromC:c.text];
+
+    // Then
+    [verify(b) processStringFromC:c.text];
+}
+
 - (void)testVerify_whileNotStubbing_ShouldFail
 {
     // Given


### PR DESCRIPTION
### Summary
Fixes https://github.com/jonreid/OCMockito/issues/165 by only returning the `verificationMode` when there is a verification ongoing.

### Details
Last year I merged [this change](https://github.com/jonreid/OCMockito/pull/164) which fixed https://github.com/jonreid/OCMockito/issues/162 by adding a relation from `MKTMockingProgress` to the object it's mocking `MKTBaseMockObject` in order to prevent verifying while stubbing false positives.

This introduced a new problem: using stubs while verifying makes tests fail, as described in https://github.com/jonreid/OCMockito/issues/165. This is because now `MKTMockingProgress` does not nil out the verification mode but it does return it, so the framework tries to verify the stub.

I'm not an expert in this codebase, but I found a change that seems to work: if ab attempt to `pullVerificationMode` is made, but the mock is not the `verificationMode` defined during `verificationStarted` it not only doesn't nil out the `verificationMode` but it also doesn't return it.