### PR TITLE
Make it safe to use -mkt_arguments as a generic helper

### DIFF
--- a/Source/OCMockito/Invocation/NSInvocation+OCMockito.m
+++ b/Source/OCMockito/Invocation/NSInvocation+OCMockito.m
@@ -15,6 +15,8 @@
 
 - (NSArray *)mkt_arguments
 {
+    [self retainArguments]; // make sure no stack blocks are added to the autoreleased array that can outlive them
+
     NSMethodSignature *signature = self.methodSignature;
     NSUInteger numberOfArguments = signature.numberOfArguments;
     NSMutableArray *arguments = [NSMutableArray arrayWithCapacity:numberOfArguments - 2];

--- a/Source/Tests/NSInvocation+OCMockitoTests.m
+++ b/Source/Tests/NSInvocation+OCMockitoTests.m
@@ -63,4 +63,11 @@
     assertThat([invocation target], is(sameInstance(weakProxy)));
 }
 
+- (void)testArguments_ShouldCopyStackBlocks
+{
+    assertThat(@(invocation.argumentsRetained), isFalse());
+    [invocation mkt_arguments];
+    assertThat(@(invocation.argumentsRetained), isTrue());
+}
+
 @end


### PR DESCRIPTION
Currently it is not safe to use `-[NSInvocation mkt_arguments]` with `NSInvocation` objects that *don't* come from OCMockito itself, as it doesn't call `-[NSInvocation retainArguments]` before adding the argument values to an autoreleased `NSArray`. Meaning that if the `NSInvocation` object has a stack block argument, it would be added as is to the `NSArray` as `-[__NSStackBlock__ retain]` does nothing. And the program might crash if the [autorelease elision](https://www.mikeash.com/pyblog/friday-qa-2014-05-09-when-an-autorelease-isnt.html) *optimisation* happens to not be performed by the objc runtime on the array, and the array ends up in an autorelease pool outliving the stack block and segfaults when trying to release the block during deallocation when the pool is finally popped.

It is safe to use `-mkt_arguments` with `NSInvocation` objects produced by OCMockito itself as `-[NSInvocation retainArguments]` is automatically called via:
* `-[NSInvocation mkt_retainArgumentsWithWeakTarget]`
* `-[MKTInvocationContainer setInvocationForPotentialStubbing:]`
* `-[MKTBaseMockObject forwardInvocation:]`

It is trivial, safe and cheap to add a call to `-retainArguments` at the start of `-mkt_arguments` as it doesn't do anything in case if the arguments have already been retained, which is the case for `NSInvocation` objects produced by OCMockito itself. 

And this makes it safe and convenient to use `-mkt_arguments` as a generic helper for any `NSInvocation` objects regardless of their provenance.